### PR TITLE
feat: add postgresql/no-select-star rule

### DIFF
--- a/.changeset/no-select-star.md
+++ b/.changeset/no-select-star.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-select-star` rule: warns on `SELECT *` and `<alias>.*` so result schemas stay stable when the underlying table changes. Off by default; opt in by setting it in your ESLint config.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5c51dfc6-6cc7-479a-93f9-24bdcd6fee42","pid":94853,"procStart":"Wed May 13 14:58:05 2026","acquiredAt":1778687936277}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ SELECT * FROM WHERE id = 1;
 SELECT * FROM users WHERE id = 1;
 ```
 
+### `postgresql/no-select-star`
+
+Disallows `SELECT *` (and `<alias>.*`). Listing columns explicitly keeps result schemas stable when the underlying table evolves and avoids accidentally pulling new sensitive columns into a query.
+
+**Type**: Suggestion  
+**Recommended**: ❌ Off by default  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT * FROM users;
+SELECT u.* FROM users u;
+```
+
+✅ Correct:
+
+```sql
+SELECT id, name FROM users;
+SELECT count(*) FROM users; -- aggregate star is fine
+```
+
 ### `postgresql/require-limit`
 
 Requires LIMIT clause in SELECT statements. Prevents accidentally retrieving large amounts of data.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { ESLint, Linter } from "eslint";
 import postgresqlParser from "postgresql-eslint-parser";
 import { name, version } from "./meta.js";
+import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import requireLimit from "./rules/require-limit.js";
 
@@ -10,6 +11,7 @@ const plugin: ESLint.Plugin = {
     version,
   },
   rules: {
+    "no-select-star": noSelectStar,
     "no-syntax-error": noSyntaxError,
     "require-limit": requireLimit,
   },

--- a/src/rules/no-select-star.ts
+++ b/src/rules/no-select-star.ts
@@ -1,0 +1,40 @@
+import type { Rule } from "eslint";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `SELECT *` in queries to keep result schemas stable when the underlying table changes",
+      category: "Best Practices",
+      recommended: false,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noSelectStar:
+        "Avoid `SELECT *`; list the columns you need so the result schema does not silently change when the table does.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: any) {
+        const targetList = node.targetList;
+        if (!Array.isArray(targetList)) return;
+        for (const target of targetList) {
+          const val = target?.val;
+          if (
+            val &&
+            val.type === "ColumnRef" &&
+            Array.isArray(val.fields) &&
+            val.fields.some((f: any) => f && f.type === "A_Star")
+          ) {
+            context.report({ node: target, messageId: "noSelectStar" });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-select-star/invalid/qualified-star-errors.expected.json
+++ b/tests/fixtures/no-select-star/invalid/qualified-star-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noSelectStar"
+  }
+]

--- a/tests/fixtures/no-select-star/invalid/qualified-star.sql
+++ b/tests/fixtures/no-select-star/invalid/qualified-star.sql
@@ -1,0 +1,1 @@
+SELECT u.* FROM users u;

--- a/tests/fixtures/no-select-star/invalid/select-star-errors.expected.json
+++ b/tests/fixtures/no-select-star/invalid/select-star-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noSelectStar"
+  }
+]

--- a/tests/fixtures/no-select-star/invalid/select-star.sql
+++ b/tests/fixtures/no-select-star/invalid/select-star.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/tests/fixtures/no-select-star/valid/count-star-is-fine.sql
+++ b/tests/fixtures/no-select-star/valid/count-star-is-fine.sql
@@ -1,0 +1,1 @@
+SELECT count(*) FROM users;

--- a/tests/fixtures/no-select-star/valid/explicit-columns.sql
+++ b/tests/fixtures/no-select-star/valid/explicit-columns.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users LIMIT 10;

--- a/tests/no-select-star.test.ts
+++ b/tests/no-select-star.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-select-star.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-select-star", rule, "should disallow SELECT *");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New opt-in rule `postgresql/no-select-star` that flags `SELECT *` and `<alias>.*` in target lists. The rule keeps query result schemas stable when the table evolves and prevents new sensitive columns from being pulled into queries that did not opt in.

## Motivation

`SELECT *` is one of the most common PostgreSQL anti-patterns in application code paths: a column added later (e.g., a soft-deletion flag, a PII column) silently appears in every consumer that uses the star. Aggregate `count(*)` is unaffected because it is not a target list star.

## Stacked on #60

This PR branches off the OSS scaffolding branch (`chore/oss-scaffolding`, PR #60) so CI has the pnpm-pin fix in place. Merge #60 first; this PR's diff against \`main\` will then reduce to just the rule.

## Changes

- New rule \`postgresql/no-select-star\` (Suggestion type, opt-in).
- Registered in \`src/index.ts\`.
- README rule docs.
- Unit test + fixtures (valid: explicit columns / \`count(*)\`; invalid: \`SELECT *\` / \`u.*\`).
- Changeset (\`minor\`).

## Testing

\`\`\`bash
pnpm test tests/no-select-star.test.ts
pnpm check:all
\`\`\`

All gates pass locally.

## Breaking changes

None. Off by default, so existing users see no change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->