### PR TITLE
feat: add postgresql/require-where-in-update rule

### DIFF
--- a/.changeset/require-where-in-update.md
+++ b/.changeset/require-where-in-update.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/require-where-in-update` rule: errors on `UPDATE` statements without a `WHERE` clause. Enabled at `error` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ SELECT count(*) FROM users; -- aggregate star is fine
 
 Errors on `DELETE` statements that have no `WHERE` clause — deleting every row in a table is almost always a mistake. Use `TRUNCATE` if you really mean to empty the table.
 
+### `postgresql/require-where-in-update`
+
+Errors on `UPDATE` statements without a `WHERE` clause — updating every row in a table is almost always a mistake.
+
 **Type**: Problem  
 **Recommended**: ✅ Error  
 **Fixable**: ❌ No
@@ -122,6 +126,7 @@ Errors on `DELETE` statements that have no `WHERE` clause — deleting every row
 
 ```sql
 DELETE FROM users;
+UPDATE users SET active = false;
 ```
 
 ✅ Correct:
@@ -129,6 +134,7 @@ DELETE FROM users;
 ```sql
 DELETE FROM users WHERE id = 1;
 DELETE FROM sessions WHERE expires_at < now();
+UPDATE users SET active = false WHERE id = 1;
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import requireLimit from "./rules/require-limit.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
+import requireWhereInUpdate from "./rules/require-where-in-update.js";
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -16,6 +17,7 @@ const plugin: ESLint.Plugin = {
     "no-syntax-error": noSyntaxError,
     "require-limit": requireLimit,
     "require-where-in-delete": requireWhereInDelete,
+    "require-where-in-update": requireWhereInUpdate,
   },
   configs: {
     recommended: {
@@ -27,6 +29,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-syntax-error": "error",
         "postgresql/require-limit": "warn",
         "postgresql/require-where-in-delete": "error",
+        "postgresql/require-where-in-update": "error",
       },
     } satisfies Linter.Config,
   },

--- a/src/rules/require-where-in-update.ts
+++ b/src/rules/require-where-in-update.ts
@@ -1,0 +1,29 @@
+import type { Rule } from "eslint";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require a WHERE clause in UPDATE statements",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missingWhere:
+        "UPDATE without WHERE rewrites every row in the table. Add a WHERE clause to scope the change.",
+    },
+  },
+  create(context) {
+    return {
+      UpdateStmt(node: any) {
+        if (!node.whereClause) {
+          context.report({ node, messageId: "missingWhere" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/require-where-in-update/invalid/update-without-where-errors.expected.json
+++ b/tests/fixtures/require-where-in-update/invalid/update-without-where-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "missingWhere"
+  }
+]

--- a/tests/fixtures/require-where-in-update/invalid/update-without-where.sql
+++ b/tests/fixtures/require-where-in-update/invalid/update-without-where.sql
@@ -1,0 +1,1 @@
+UPDATE users SET active = false;

--- a/tests/fixtures/require-where-in-update/valid/update-with-where.sql
+++ b/tests/fixtures/require-where-in-update/valid/update-with-where.sql
@@ -1,0 +1,1 @@
+UPDATE users SET name = 'a' WHERE id = 1;

--- a/tests/require-where-in-update.test.ts
+++ b/tests/require-where-in-update.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/require-where-in-update.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "require-where-in-update",
+  rule,
+  "should require WHERE in UPDATE statements",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/require-where-in-update` that errors on `UPDATE` statements without a `WHERE` clause. Enabled at error severity in `configs.recommended`.

## Motivation

Like `DELETE` without `WHERE`, `UPDATE` without `WHERE` is almost always an incident (think `UPDATE users SET active = false;` over the entire user table). Zero practical false-positive surface.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/require-where-in-update`.
- Wired into `configs.recommended` at `error`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on rule in `configs.recommended` (pre-1.0 acceptable). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->