### PR TITLE
feat: add postgresql/no-truncate-cascade rule

### DIFF
--- a/.changeset/no-truncate-cascade.md
+++ b/.changeset/no-truncate-cascade.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-truncate-cascade` rule: warns on `TRUNCATE ... CASCADE` because it transitively empties tables that have foreign keys referencing the target. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Errors on `UPDATE` statements without a `WHERE` clause — updating every row in
 ### `postgresql/no-drop-table-cascade`
 
 Warns on `DROP TABLE ... CASCADE`. `CASCADE` silently removes dependent objects (views, foreign keys, sequences) and is one of the most common ways migrations destroy more than intended. The fix is to list the dependents explicitly. The rule scopes to `DROP TABLE` to match its name; other `DROP ... CASCADE` variants (schema, type, etc.) are not covered.
+### `postgresql/no-truncate-cascade`
+
+Warns on `TRUNCATE ... CASCADE`. CASCADE on TRUNCATE transitively empties every table that has a foreign key referencing the target, which is essentially never the right tool for the intended operation.
 
 **Type**: Problem  
 **Recommended**: ⚠️ Warn  
@@ -134,6 +137,7 @@ Warns on `DROP TABLE ... CASCADE`. `CASCADE` silently removes dependent objects 
 DELETE FROM users;
 UPDATE users SET active = false;
 DROP TABLE users CASCADE;
+TRUNCATE users CASCADE;
 ```
 
 ✅ Correct:
@@ -144,6 +148,8 @@ DELETE FROM sessions WHERE expires_at < now();
 UPDATE users SET active = false WHERE id = 1;
 DROP TABLE users;
 DROP TABLE users RESTRICT;
+TRUNCATE users;
+TRUNCATE users RESTRICT;
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { name, version } from "./meta.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
+import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import requireLimit from "./rules/require-limit.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
@@ -17,6 +18,7 @@ const plugin: ESLint.Plugin = {
     "no-select-star": noSelectStar,
     "no-drop-table-cascade": noDropTableCascade,
     "no-syntax-error": noSyntaxError,
+    "no-truncate-cascade": noTruncateCascade,
     "require-limit": requireLimit,
     "require-where-in-delete": requireWhereInDelete,
     "require-where-in-update": requireWhereInUpdate,
@@ -30,6 +32,7 @@ const plugin: ESLint.Plugin = {
       rules: {
         "postgresql/no-drop-table-cascade": "warn",
         "postgresql/no-syntax-error": "error",
+        "postgresql/no-truncate-cascade": "warn",
         "postgresql/require-limit": "warn",
         "postgresql/require-where-in-delete": "error",
         "postgresql/require-where-in-update": "error",

--- a/src/rules/no-truncate-cascade.ts
+++ b/src/rules/no-truncate-cascade.ts
@@ -1,0 +1,30 @@
+import type { Rule } from "eslint";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `TRUNCATE ... CASCADE` because it transitively empties referencing tables",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCascade:
+        "`TRUNCATE ... CASCADE` also truncates every table that has a foreign key referencing this one. List the dependent tables explicitly so reviewers can see what gets emptied.",
+    },
+  },
+  create(context) {
+    return {
+      TruncateStmt(node: any) {
+        if (node.behavior === "DROP_CASCADE") {
+          context.report({ node, messageId: "noCascade" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-truncate-cascade/invalid/truncate-cascade-errors.expected.json
+++ b/tests/fixtures/no-truncate-cascade/invalid/truncate-cascade-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noCascade"
+  }
+]

--- a/tests/fixtures/no-truncate-cascade/invalid/truncate-cascade.sql
+++ b/tests/fixtures/no-truncate-cascade/invalid/truncate-cascade.sql
@@ -1,0 +1,1 @@
+TRUNCATE users CASCADE;

--- a/tests/fixtures/no-truncate-cascade/valid/truncate-restrict.sql
+++ b/tests/fixtures/no-truncate-cascade/valid/truncate-restrict.sql
@@ -1,0 +1,1 @@
+TRUNCATE users RESTRICT;

--- a/tests/fixtures/no-truncate-cascade/valid/truncate.sql
+++ b/tests/fixtures/no-truncate-cascade/valid/truncate.sql
@@ -1,0 +1,1 @@
+TRUNCATE users;

--- a/tests/no-truncate-cascade.test.ts
+++ b/tests/no-truncate-cascade.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-truncate-cascade.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-truncate-cascade",
+  rule,
+  "should disallow TRUNCATE ... CASCADE",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/no-truncate-cascade` that warns on `TRUNCATE ... CASCADE`. Enabled at `warn` in `configs.recommended`.

## Motivation

`CASCADE` on `TRUNCATE` transitively empties referencing tables, which is virtually never the right semantics for the user's stated intent ("empty this one table").

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/no-truncate-cascade`.
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->