### PR TITLE
feat: add postgresql/prefer-jsonb-over-json rule

### DIFF
--- a/.changeset/prefer-jsonb-over-json.md
+++ b/.changeset/prefer-jsonb-over-json.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-jsonb-over-json` rule: warns on columns declared as `json` and recommends `jsonb`. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Errors on `NATURAL JOIN`. The join columns are implicit — any new column added
 
 **Type**: Problem  
 **Recommended**: ✅ Error  
+### `postgresql/prefer-jsonb-over-json`
+
+Warns on columns declared as `json`. `jsonb` stores the parsed representation, supports GIN indexes, and is what application code almost always wants. `json` only makes sense if you specifically need byte-exact round-tripping of the input text.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
 **Fixable**: ❌ No
 
 #### Examples
@@ -151,6 +157,7 @@ DROP TABLE users CASCADE;
 TRUNCATE users CASCADE;
 SELECT * FROM a CROSS JOIN b;
 SELECT * FROM a NATURAL JOIN b;
+CREATE TABLE events (payload JSON);
 ```
 
 ✅ Correct:
@@ -168,6 +175,7 @@ SELECT * FROM a INNER JOIN b USING (id);
 SELECT * FROM a JOIN b ON true; -- intentional cartesian
 SELECT * FROM a JOIN b USING (id);
 SELECT * FROM a JOIN b ON a.id = b.id;
+CREATE TABLE events (payload JSONB);
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import noCrossJoin from "./rules/no-cross-join.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
+import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
 import requireLimit from "./rules/require-limit.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
@@ -23,6 +24,7 @@ const plugin: ESLint.Plugin = {
     "no-natural-join": noNaturalJoin,
     "no-syntax-error": noSyntaxError,
     "no-truncate-cascade": noTruncateCascade,
+    "prefer-jsonb-over-json": preferJsonbOverJson,
     "require-limit": requireLimit,
     "require-where-in-delete": requireWhereInDelete,
     "require-where-in-update": requireWhereInUpdate,
@@ -39,6 +41,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-natural-join": "error",
         "postgresql/no-syntax-error": "error",
         "postgresql/no-truncate-cascade": "warn",
+        "postgresql/prefer-jsonb-over-json": "warn",
         "postgresql/require-limit": "warn",
         "postgresql/require-where-in-delete": "error",
         "postgresql/require-where-in-update": "error",

--- a/src/rules/prefer-jsonb-over-json.ts
+++ b/src/rules/prefer-jsonb-over-json.ts
@@ -1,0 +1,43 @@
+import type { Rule } from "eslint";
+
+const getTypeName = (typeName: any): string | undefined => {
+  if (!typeName || typeof typeName !== "object") return undefined;
+  // typeName carries the qualified name across numeric-string keys "0", "1", ...
+  // The unqualified type name is at the highest-numbered segment; lower
+  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
+  // segment-1 name when present so `public.varchar` still resolves to
+  // `varchar` and not the schema.
+  const v1 = typeName["1"]?.sval;
+  if (typeof v1 === "string") return v1;
+  const v0 = typeName["0"]?.sval;
+  if (typeof v0 === "string") return v0;
+  return undefined;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer `jsonb` over `json` for column types",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferJsonb:
+        "Use `jsonb` instead of `json`. `jsonb` stores the parsed representation, supports indexing, and is what almost every application actually wants.",
+    },
+  },
+  create(context) {
+    const check = (node: any) => {
+      const t = getTypeName(node?.typeName);
+      if (t === "json") {
+        context.report({ node, messageId: "preferJsonb" });
+      }
+    };
+    return { ColumnDef: check };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-jsonb-over-json/invalid/json-column-errors.expected.json
+++ b/tests/fixtures/prefer-jsonb-over-json/invalid/json-column-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferJsonb"
+  }
+]

--- a/tests/fixtures/prefer-jsonb-over-json/invalid/json-column.sql
+++ b/tests/fixtures/prefer-jsonb-over-json/invalid/json-column.sql
@@ -1,0 +1,1 @@
+CREATE TABLE events (payload JSON);

--- a/tests/fixtures/prefer-jsonb-over-json/invalid/qualified-json-errors.expected.json
+++ b/tests/fixtures/prefer-jsonb-over-json/invalid/qualified-json-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferJsonb"
+  }
+]

--- a/tests/fixtures/prefer-jsonb-over-json/invalid/qualified-json.sql
+++ b/tests/fixtures/prefer-jsonb-over-json/invalid/qualified-json.sql
@@ -1,0 +1,1 @@
+CREATE TABLE events (payload pg_catalog.json);

--- a/tests/fixtures/prefer-jsonb-over-json/valid/jsonb-column.sql
+++ b/tests/fixtures/prefer-jsonb-over-json/valid/jsonb-column.sql
@@ -1,0 +1,1 @@
+CREATE TABLE events (payload JSONB);

--- a/tests/fixtures/prefer-jsonb-over-json/valid/other-column.sql
+++ b/tests/fixtures/prefer-jsonb-over-json/valid/other-column.sql
@@ -1,0 +1,1 @@
+CREATE TABLE events (id INT);

--- a/tests/prefer-jsonb-over-json.test.ts
+++ b/tests/prefer-jsonb-over-json.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-jsonb-over-json.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-jsonb-over-json",
+  rule,
+  "should prefer jsonb over json column type",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/prefer-jsonb-over-json` that warns on columns declared as `json` and recommends `jsonb`. Enabled at `warn` in `configs.recommended`.

## Motivation

`json` stores the raw input text and re-parses on every access; `jsonb` stores the parsed representation and supports GIN indexes. Application code almost always wants `jsonb`. `json` only makes sense when the consumer needs byte-exact round-trip of the original text.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/prefer-jsonb-over-json`.
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->