### PR TITLE
feat: add postgresql/prefer-text-over-varchar rule

### DIFF
--- a/.changeset/prefer-text-over-varchar.md
+++ b/.changeset/prefer-text-over-varchar.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-text-over-varchar` rule: warns on `varchar(n)` and recommends `text` with a `CHECK` constraint when a length cap is needed. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Warns on `SMALLSERIAL`, `SERIAL`, `BIGSERIAL` columns. The serial pseudo-types c
 ### `postgresql/require-primary-key`
 
 Warns on `CREATE TABLE` statements without a primary key — either column-level (`id INT PRIMARY KEY`) or table-level (`PRIMARY KEY (id)`). Tables without a primary key cannot be replicated cleanly with logical replication, are hard to shard, and break most ORMs and migration tools. The rule does not flag `CREATE TABLE ... PARTITION OF ...` (no `tableElts`); a partition inherits its parent's primary key.
+### `postgresql/prefer-text-over-varchar`
+
+Warns on `varchar(n)` columns. PostgreSQL stores `text` and `varchar(n)` the same way internally; the length is enforced by a per-table constraint that you cannot relax without rewriting the table. Use `text` and add a `CHECK (length(col) <= N)` constraint when you actually need a cap.
 
 **Type**: Suggestion  
 **Recommended**: ⚠️ Warn  
@@ -167,6 +170,7 @@ CREATE TABLE events (payload JSON);
 CREATE TABLE t (id BIGSERIAL);
 CREATE TABLE t (id SERIAL);
 CREATE TABLE t (id INT, name TEXT);
+CREATE TABLE users (name VARCHAR(255));
 ```
 
 ✅ Correct:
@@ -189,6 +193,12 @@ CREATE TABLE t (id BIGINT GENERATED ALWAYS AS IDENTITY);
 CREATE TABLE t (id INT PRIMARY KEY, name TEXT);
 CREATE TABLE t (id INT, name TEXT, PRIMARY KEY (id));
 ```
+
+CREATE TABLE users (name TEXT);
+CREATE TABLE users (name TEXT CHECK (length(name) <= 255));
+```
+
+`VARCHAR` without a length limit is also allowed.
 
 ### `postgresql/require-limit`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
+import preferTextOverVarchar from "./rules/prefer-text-over-varchar.js";
 import requireLimit from "./rules/require-limit.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
@@ -28,6 +29,7 @@ const plugin: ESLint.Plugin = {
     "no-truncate-cascade": noTruncateCascade,
     "prefer-jsonb-over-json": preferJsonbOverJson,
     "prefer-identity-over-serial": preferIdentityOverSerial,
+    "prefer-text-over-varchar": preferTextOverVarchar,
     "require-limit": requireLimit,
     "require-where-in-delete": requireWhereInDelete,
     "require-where-in-update": requireWhereInUpdate,
@@ -47,6 +49,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-truncate-cascade": "warn",
         "postgresql/prefer-jsonb-over-json": "warn",
         "postgresql/prefer-identity-over-serial": "warn",
+        "postgresql/prefer-text-over-varchar": "warn",
         "postgresql/require-limit": "warn",
         "postgresql/require-where-in-delete": "error",
         "postgresql/require-where-in-update": "error",

--- a/src/rules/prefer-text-over-varchar.ts
+++ b/src/rules/prefer-text-over-varchar.ts
@@ -1,0 +1,45 @@
+import type { Rule } from "eslint";
+
+const getTypeName = (typeName: any): string | undefined => {
+  if (!typeName || typeof typeName !== "object") return undefined;
+  // typeName carries the qualified name across numeric-string keys "0", "1", ...
+  // The unqualified type name is at the highest-numbered segment; lower
+  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
+  // segment-1 name when present so `public.varchar` still resolves to
+  // `varchar` and not the schema.
+  const v1 = typeName["1"]?.sval;
+  if (typeof v1 === "string") return v1;
+  const v0 = typeName["0"]?.sval;
+  if (typeof v0 === "string") return v0;
+  return undefined;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer `text` over `varchar(n)`; a length limit belongs in a CHECK constraint, not the type",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferText:
+        "Use `text` instead of `varchar(n)`. PostgreSQL stores both the same way; the length cap is enforced by a constraint that you cannot relax without a full table rewrite. Move the limit into a CHECK constraint.",
+    },
+  },
+  create(context) {
+    return {
+      ColumnDef(node: any) {
+        const t = getTypeName(node?.typeName);
+        if (t === "varchar" && Array.isArray(node.typeName?.typmods)) {
+          context.report({ node, messageId: "preferText" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-text-over-varchar/invalid/varchar-n-errors.expected.json
+++ b/tests/fixtures/prefer-text-over-varchar/invalid/varchar-n-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferText"
+  }
+]

--- a/tests/fixtures/prefer-text-over-varchar/invalid/varchar-n.sql
+++ b/tests/fixtures/prefer-text-over-varchar/invalid/varchar-n.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (name VARCHAR(255));

--- a/tests/fixtures/prefer-text-over-varchar/valid/text-column.sql
+++ b/tests/fixtures/prefer-text-over-varchar/valid/text-column.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (name TEXT);

--- a/tests/fixtures/prefer-text-over-varchar/valid/unlimited-varchar.sql
+++ b/tests/fixtures/prefer-text-over-varchar/valid/unlimited-varchar.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (name VARCHAR);

--- a/tests/prefer-text-over-varchar.test.ts
+++ b/tests/prefer-text-over-varchar.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-text-over-varchar.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-text-over-varchar",
+  rule,
+  "should prefer text over varchar(n)",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/prefer-text-over-varchar` that warns on `varchar(n)` columns. Enabled at `warn` in `configs.recommended`.

## Motivation

PostgreSQL stores `text` and `varchar(n)` the same way internally. The length is a constraint that you cannot relax without a full table rewrite, which makes it a poor place to encode "we want at most N chars" — that belongs in a `CHECK` constraint that can be edited via `ALTER TABLE ... DROP CONSTRAINT` + a new one. `VARCHAR` without a length is unaffected.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/prefer-text-over-varchar` (only fires when `varchar` has a typmod).
- Wired into `configs.recommended` at `warn`.
- README rule docs with the `CHECK (length(...) <= N)` migration suggestion.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->