### PR TITLE
feat: add postgresql/no-money-type rule

### DIFF
--- a/.changeset/no-money-type.md
+++ b/.changeset/no-money-type.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-money-type` rule: errors on the `money` column type. Enabled at `error` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Disallows `SELECT *` (and `<alias>.*`). Listing columns explicitly keeps result 
 
 **Type**: Suggestion  
 **Recommended**: ❌ Off by default  
+### `postgresql/no-money-type`
+
+Errors on the `money` column type. Its output format and precision depend on the server's `lc_monetary` setting, so the same row prints differently on different servers and round-trips badly through clients. The PostgreSQL recommendation is `numeric` (and a separate currency column when you have more than one currency).
+
+**Type**: Problem  
+**Recommended**: ✅ Error  
 **Fixable**: ❌ No
 
 #### Examples
@@ -99,6 +105,7 @@ Disallows `SELECT *` (and `<alias>.*`). Listing columns explicitly keeps result 
 ```sql
 SELECT * FROM users;
 SELECT u.* FROM users u;
+CREATE TABLE t (price MONEY);
 ```
 
 ✅ Correct:
@@ -206,6 +213,7 @@ CREATE TABLE users (name TEXT CHECK (length(name) <= 255));
 
 CREATE TABLE t (created_at TIMESTAMPTZ);
 CREATE TABLE t (created_at TIMESTAMP WITH TIME ZONE);
+CREATE TABLE t (price NUMERIC(10, 2), currency CHAR(3));
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import noSelectStar from "./rules/no-select-star.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
+import noMoneyType from "./rules/no-money-type.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -26,6 +27,7 @@ const plugin: ESLint.Plugin = {
     "no-drop-table-cascade": noDropTableCascade,
     "no-cross-join": noCrossJoin,
     "no-natural-join": noNaturalJoin,
+    "no-money-type": noMoneyType,
     "no-syntax-error": noSyntaxError,
     "no-truncate-cascade": noTruncateCascade,
     "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -47,6 +49,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-drop-table-cascade": "warn",
         "postgresql/no-cross-join": "warn",
         "postgresql/no-natural-join": "error",
+        "postgresql/no-money-type": "error",
         "postgresql/no-syntax-error": "error",
         "postgresql/no-truncate-cascade": "warn",
         "postgresql/prefer-jsonb-over-json": "warn",

--- a/src/rules/no-money-type.ts
+++ b/src/rules/no-money-type.ts
@@ -1,0 +1,44 @@
+import type { Rule } from "eslint";
+
+const getTypeName = (typeName: any): string | undefined => {
+  if (!typeName || typeof typeName !== "object") return undefined;
+  // typeName carries the qualified name across numeric-string keys "0", "1", ...
+  // The unqualified type name is at the highest-numbered segment; lower
+  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
+  // segment-1 name when present so `public.varchar` still resolves to
+  // `varchar` and not the schema.
+  const v1 = typeName["1"]?.sval;
+  if (typeof v1 === "string") return v1;
+  const v0 = typeName["0"]?.sval;
+  if (typeof v0 === "string") return v0;
+  return undefined;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow the `money` column type",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noMoney:
+        "Avoid `money`. Its output format and precision depend on `lc_monetary`, so the same row looks different on different servers and round-trips badly. Store amounts as `numeric` and keep the currency in a separate column.",
+    },
+  },
+  create(context) {
+    return {
+      ColumnDef(node: any) {
+        const t = getTypeName(node?.typeName);
+        if (t === "money") {
+          context.report({ node, messageId: "noMoney" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-money-type/invalid/money-errors.expected.json
+++ b/tests/fixtures/no-money-type/invalid/money-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noMoney"
+  }
+]

--- a/tests/fixtures/no-money-type/invalid/money.sql
+++ b/tests/fixtures/no-money-type/invalid/money.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (price MONEY);

--- a/tests/fixtures/no-money-type/valid/numeric.sql
+++ b/tests/fixtures/no-money-type/valid/numeric.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (price NUMERIC(10, 2));

--- a/tests/no-money-type.test.ts
+++ b/tests/no-money-type.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-money-type.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-money-type", rule, "should disallow money column type");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/no-money-type` that errors on `money` columns. Enabled at `error` in `configs.recommended`.

## Motivation

The `money` type's output format and precision depend on `lc_monetary`, so the same row prints differently on different servers and round-trips badly through ORM and client layers. The PostgreSQL team's own recommendation is `numeric` with a separate currency column.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/no-money-type`.
- Wired into `configs.recommended` at `error`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on rule in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->