### PR TITLE
feat: add postgresql/no-char-type rule

### DIFF
--- a/.changeset/no-char-type.md
+++ b/.changeset/no-char-type.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-char-type` rule: warns on blank-padded `char(n)` / `bpchar` columns. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Warns on `varchar(n)` columns. PostgreSQL stores `text` and `varchar(n)` the sam
 ### `postgresql/prefer-timestamptz`
 
 Warns on `timestamp` (i.e. `timestamp without time zone`) columns. `timestamp` is timezone-naive: it stores the wall-clock literal you handed in and assumes every reader and writer share the same convention. Two clients with different `TimeZone` settings will disagree on which instant a row represents. `timestamptz` anchors everything to UTC at storage time and converts to the session timezone on read, which is what application code almost always wants.
+### `postgresql/no-char-type`
+
+Warns on `char(n)` (a.k.a. `bpchar`) columns. PostgreSQL pads stored `char(n)` values to `n` with trailing spaces and silently trims on read; the padding surprises comparisons, sorts, and round-trip pipelines. Use `text` (and a `CHECK` constraint if you need a length).
 
 **Type**: Suggestion  
 **Recommended**: ⚠️ Warn  
@@ -182,6 +185,8 @@ CREATE TABLE t (id SERIAL);
 CREATE TABLE t (id INT, name TEXT);
 CREATE TABLE users (name VARCHAR(255));
 CREATE TABLE t (created_at TIMESTAMP);
+CREATE TABLE t (code CHAR(3));
+CREATE TABLE t (code BPCHAR(3));
 ```
 
 ✅ Correct:
@@ -214,6 +219,8 @@ CREATE TABLE users (name TEXT CHECK (length(name) <= 255));
 CREATE TABLE t (created_at TIMESTAMPTZ);
 CREATE TABLE t (created_at TIMESTAMP WITH TIME ZONE);
 CREATE TABLE t (price NUMERIC(10, 2), currency CHAR(3));
+CREATE TABLE t (code TEXT);
+CREATE TABLE t (code TEXT CHECK (length(code) = 3));
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noMoneyType from "./rules/no-money-type.js";
+import noCharType from "./rules/no-char-type.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -28,6 +29,7 @@ const plugin: ESLint.Plugin = {
     "no-cross-join": noCrossJoin,
     "no-natural-join": noNaturalJoin,
     "no-money-type": noMoneyType,
+    "no-char-type": noCharType,
     "no-syntax-error": noSyntaxError,
     "no-truncate-cascade": noTruncateCascade,
     "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -50,6 +52,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-cross-join": "warn",
         "postgresql/no-natural-join": "error",
         "postgresql/no-money-type": "error",
+        "postgresql/no-char-type": "warn",
         "postgresql/no-syntax-error": "error",
         "postgresql/no-truncate-cascade": "warn",
         "postgresql/prefer-jsonb-over-json": "warn",

--- a/src/rules/no-char-type.ts
+++ b/src/rules/no-char-type.ts
@@ -1,0 +1,44 @@
+import type { Rule } from "eslint";
+
+const getTypeName = (typeName: any): string | undefined => {
+  if (!typeName || typeof typeName !== "object") return undefined;
+  // typeName carries the qualified name across numeric-string keys "0", "1", ...
+  // The unqualified type name is at the highest-numbered segment; lower
+  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
+  // segment-1 name when present so `public.varchar` still resolves to
+  // `varchar` and not the schema.
+  const v1 = typeName["1"]?.sval;
+  if (typeof v1 === "string") return v1;
+  const v0 = typeName["0"]?.sval;
+  if (typeof v0 === "string") return v0;
+  return undefined;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow the blank-padded `char(n)` / `bpchar` column type",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noChar:
+        "Avoid `char(n)`. PostgreSQL pads stored values to `n` with trailing spaces and trims on read, which surprises every comparison and round-trip. Use `text` instead.",
+    },
+  },
+  create(context) {
+    return {
+      ColumnDef(node: any) {
+        const t = getTypeName(node?.typeName);
+        if (t === "bpchar") {
+          context.report({ node, messageId: "noChar" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-char-type/invalid/bpchar-errors.expected.json
+++ b/tests/fixtures/no-char-type/invalid/bpchar-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noChar"
+  }
+]

--- a/tests/fixtures/no-char-type/invalid/bpchar.sql
+++ b/tests/fixtures/no-char-type/invalid/bpchar.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (code BPCHAR(3));

--- a/tests/fixtures/no-char-type/invalid/char-n-errors.expected.json
+++ b/tests/fixtures/no-char-type/invalid/char-n-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noChar"
+  }
+]

--- a/tests/fixtures/no-char-type/invalid/char-n.sql
+++ b/tests/fixtures/no-char-type/invalid/char-n.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (code CHAR(3));

--- a/tests/fixtures/no-char-type/valid/text.sql
+++ b/tests/fixtures/no-char-type/valid/text.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (code TEXT);

--- a/tests/no-char-type.test.ts
+++ b/tests/no-char-type.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-char-type.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-char-type", rule, "should disallow char(n) column type");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/no-char-type` that warns on `char(n)` / `bpchar` columns. Enabled at `warn` in `configs.recommended`.

## Motivation

`char(n)` is blank-padded — PostgreSQL pads stored values to `n` and silently trims them on read. The padding surprises every comparison, ORDER BY, and external pipeline that round-trips the column. `text` is what application code wants; a length constraint can be added explicitly with `CHECK`.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/no-char-type` (covers both `CHAR(n)` and the canonical `BPCHAR(n)`).
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->