### PR TITLE
feat: add postgresql/no-grant-to-public rule

### DIFF
--- a/.changeset/no-grant-to-public.md
+++ b/.changeset/no-grant-to-public.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-grant-to-public` rule: warns on `GRANT ... TO PUBLIC` because PUBLIC covers every current and future role. `REVOKE ... FROM PUBLIC` is unaffected. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Warns on `timestamp` (i.e. `timestamp without time zone`) columns. `timestamp` i
 Warns on `char(n)` (a.k.a. `bpchar`) columns. PostgreSQL pads stored `char(n)` values to `n` with trailing spaces and silently trims on read; the padding surprises comparisons, sorts, and round-trip pipelines. Use `text` (and a `CHECK` constraint if you need a length).
 
 **Type**: Suggestion  
+### `postgresql/no-grant-to-public`
+
+Warns on `GRANT ... TO PUBLIC`. The PUBLIC pseudo-role covers every current and future role in the database, including ones added later for unrelated services or admin tooling. Privilege grants should name the role(s) explicitly. Note that `REVOKE ... FROM PUBLIC` is unaffected — revoking the implicit grants is good hygiene.
+
+**Type**: Problem  
 **Recommended**: ⚠️ Warn  
 **Fixable**: ❌ No
 
@@ -187,6 +192,7 @@ CREATE TABLE users (name VARCHAR(255));
 CREATE TABLE t (created_at TIMESTAMP);
 CREATE TABLE t (code CHAR(3));
 CREATE TABLE t (code BPCHAR(3));
+GRANT SELECT ON users TO PUBLIC;
 ```
 
 ✅ Correct:
@@ -221,6 +227,8 @@ CREATE TABLE t (created_at TIMESTAMP WITH TIME ZONE);
 CREATE TABLE t (price NUMERIC(10, 2), currency CHAR(3));
 CREATE TABLE t (code TEXT);
 CREATE TABLE t (code TEXT CHECK (length(code) = 3));
+GRANT SELECT ON users TO reporting;
+REVOKE ALL ON users FROM PUBLIC;
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import noCrossJoin from "./rules/no-cross-join.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noMoneyType from "./rules/no-money-type.js";
 import noCharType from "./rules/no-char-type.js";
+import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -30,6 +31,7 @@ const plugin: ESLint.Plugin = {
     "no-natural-join": noNaturalJoin,
     "no-money-type": noMoneyType,
     "no-char-type": noCharType,
+    "no-grant-to-public": noGrantToPublic,
     "no-syntax-error": noSyntaxError,
     "no-truncate-cascade": noTruncateCascade,
     "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -53,6 +55,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-natural-join": "error",
         "postgresql/no-money-type": "error",
         "postgresql/no-char-type": "warn",
+        "postgresql/no-grant-to-public": "warn",
         "postgresql/no-syntax-error": "error",
         "postgresql/no-truncate-cascade": "warn",
         "postgresql/prefer-jsonb-over-json": "warn",

--- a/src/rules/no-grant-to-public.ts
+++ b/src/rules/no-grant-to-public.ts
@@ -1,0 +1,35 @@
+import type { Rule } from "eslint";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow GRANT statements that target the `PUBLIC` pseudo-role",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noPublic:
+        "Avoid `GRANT ... TO PUBLIC`. The PUBLIC role covers every current and future role in the database, including ones added later for unrelated services. Name the role(s) you actually want to grant to.",
+    },
+  },
+  create(context) {
+    return {
+      GrantStmt(node: any) {
+        if (!node.is_grant) return;
+        const grantees = Array.isArray(node.grantees) ? node.grantees : [];
+        for (const g of grantees) {
+          if (g?.roletype === "ROLESPEC_PUBLIC") {
+            context.report({ node, messageId: "noPublic" });
+            return;
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-grant-to-public/invalid/grant-to-public-errors.expected.json
+++ b/tests/fixtures/no-grant-to-public/invalid/grant-to-public-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noPublic"
+  }
+]

--- a/tests/fixtures/no-grant-to-public/invalid/grant-to-public.sql
+++ b/tests/fixtures/no-grant-to-public/invalid/grant-to-public.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON users TO PUBLIC;

--- a/tests/fixtures/no-grant-to-public/valid/grant-to-role.sql
+++ b/tests/fixtures/no-grant-to-public/valid/grant-to-role.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON users TO reporting;

--- a/tests/fixtures/no-grant-to-public/valid/revoke-from-public.sql
+++ b/tests/fixtures/no-grant-to-public/valid/revoke-from-public.sql
@@ -1,0 +1,1 @@
+REVOKE ALL ON users FROM PUBLIC;

--- a/tests/no-grant-to-public.test.ts
+++ b/tests/no-grant-to-public.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-grant-to-public.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-grant-to-public", rule, "should disallow GRANT ... TO PUBLIC");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/no-grant-to-public` that warns on `GRANT ... TO PUBLIC`. Enabled at `warn` in `configs.recommended`.

## Motivation

The PUBLIC pseudo-role covers every current and future role in the database, including ones created later for unrelated services or admin tooling. `GRANT ... TO PUBLIC` is therefore the most error-prone privilege target. The rule explicitly does not flag `REVOKE ... FROM PUBLIC` — revoking implicit grants is good hygiene.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/no-grant-to-public` (only fires on GRANT, not REVOKE).
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures (including a `REVOKE FROM PUBLIC` negative case).
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->