### PR TITLE
feat: add postgresql/prefer-create-index-concurrently rule

### DIFF
--- a/.changeset/prefer-create-index-concurrently.md
+++ b/.changeset/prefer-create-index-concurrently.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-create-index-concurrently` rule: warns on plain `CREATE INDEX` and recommends `CREATE INDEX CONCURRENTLY`. Off by default because the right answer depends on the migration framework.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Errors on the `money` column type. Its output format and precision depend on the
 
 **Type**: Problem  
 **Recommended**: ✅ Error  
+### `postgresql/prefer-create-index-concurrently`
+
+Warns on plain `CREATE INDEX` and recommends `CREATE INDEX CONCURRENTLY`. A non-concurrent index build takes a `SHARE` lock on the target table for the duration of the build — readers are unaffected, but every writer is blocked. Concurrent builds avoid the lock but cannot run inside a transaction — most migration tools therefore need an explicit per-step opt-out for this. Off by default because the right answer depends on your migration framework.
+
+**Type**: Suggestion  
+**Recommended**: ❌ Off by default  
 **Fixable**: ❌ No
 
 #### Examples
@@ -106,6 +112,7 @@ Errors on the `money` column type. Its output format and precision depend on the
 SELECT * FROM users;
 SELECT u.* FROM users u;
 CREATE TABLE t (price MONEY);
+CREATE INDEX idx_users_email ON users (email);
 ```
 
 ✅ Correct:
@@ -229,6 +236,7 @@ CREATE TABLE t (code TEXT);
 CREATE TABLE t (code TEXT CHECK (length(code) = 3));
 GRANT SELECT ON users TO reporting;
 REVOKE ALL ON users FROM PUBLIC;
+CREATE INDEX CONCURRENTLY idx_users_email ON users (email);
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
 import preferTextOverVarchar from "./rules/prefer-text-over-varchar.js";
 import preferTimestamptz from "./rules/prefer-timestamptz.js";
+import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import requireLimit from "./rules/require-limit.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
@@ -38,6 +39,7 @@ const plugin: ESLint.Plugin = {
     "prefer-identity-over-serial": preferIdentityOverSerial,
     "prefer-text-over-varchar": preferTextOverVarchar,
     "prefer-timestamptz": preferTimestamptz,
+    "prefer-create-index-concurrently": preferCreateIndexConcurrently,
     "require-limit": requireLimit,
     "require-where-in-delete": requireWhereInDelete,
     "require-where-in-update": requireWhereInUpdate,

--- a/src/rules/prefer-create-index-concurrently.ts
+++ b/src/rules/prefer-create-index-concurrently.ts
@@ -1,0 +1,30 @@
+import type { Rule } from "eslint";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer `CREATE INDEX CONCURRENTLY` to avoid blocking writes against the table during migrations",
+      category: "Best Practices",
+      recommended: false,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferConcurrently:
+        "Use `CREATE INDEX CONCURRENTLY`. A plain `CREATE INDEX` takes a `SHARE` lock on the target table for the duration of the build — readers are unaffected, but every writer is blocked. Concurrent index builds cannot run inside a transaction, so a migration tool that wraps each step in BEGIN/COMMIT needs an explicit opt-out here.",
+    },
+  },
+  create(context) {
+    return {
+      IndexStmt(node: any) {
+        if (!node.concurrent) {
+          context.report({ node, messageId: "preferConcurrently" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-create-index-concurrently/invalid/not-concurrent-errors.expected.json
+++ b/tests/fixtures/prefer-create-index-concurrently/invalid/not-concurrent-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferConcurrently"
+  }
+]

--- a/tests/fixtures/prefer-create-index-concurrently/invalid/not-concurrent.sql
+++ b/tests/fixtures/prefer-create-index-concurrently/invalid/not-concurrent.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_email ON users (email);

--- a/tests/fixtures/prefer-create-index-concurrently/valid/concurrent.sql
+++ b/tests/fixtures/prefer-create-index-concurrently/valid/concurrent.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx_users_email ON users (email);

--- a/tests/prefer-create-index-concurrently.test.ts
+++ b/tests/prefer-create-index-concurrently.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-create-index-concurrently.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-create-index-concurrently",
+  rule,
+  "should prefer CREATE INDEX CONCURRENTLY",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/prefer-create-index-concurrently` that warns on plain `CREATE INDEX`. Off by default — opt in per project.

## Motivation

A plain `CREATE INDEX` takes an `ACCESS EXCLUSIVE` lock for the duration of the build, blocking every writer. On a busy table this is the difference between a minute of degraded latency and a full outage. `CREATE INDEX CONCURRENTLY` avoids the lock, at the cost of not running inside a transaction. The right trade-off depends on the migration framework, so this rule ships off by default.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/prefer-create-index-concurrently`.
- Not wired into `configs.recommended` (opt-in).
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

None — off by default.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->