### PR TITLE
feat: add postgresql/no-not-in-subquery rule

### DIFF
--- a/.changeset/no-not-in-subquery.md
+++ b/.changeset/no-not-in-subquery.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-not-in-subquery` rule: errors on `NOT IN (subquery)` because a single NULL in the subquery yields zero rows. Literal `NOT IN (1, 2, 3)` lists are unaffected. Enabled at `error` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Warns on plain `CREATE INDEX` and recommends `CREATE INDEX CONCURRENTLY`. A non-
 
 **Type**: Suggestion  
 **Recommended**: ❌ Off by default  
+### `postgresql/no-not-in-subquery`
+
+Errors on `NOT IN (subquery)`. PostgreSQL's `NOT IN` returns **no rows** if the subquery yields a single NULL — semantically correct under three-valued logic, but virtually always not what application code wants. Use `NOT EXISTS (SELECT 1 FROM ... WHERE ...)`, which handles NULL the way humans expect. `NOT IN (1, 2, 3)` with a literal list is unaffected.
+
+**Type**: Problem  
+**Recommended**: ✅ Error  
 **Fixable**: ❌ No
 
 #### Examples
@@ -113,6 +119,7 @@ SELECT * FROM users;
 SELECT u.* FROM users u;
 CREATE TABLE t (price MONEY);
 CREATE INDEX idx_users_email ON users (email);
+SELECT id FROM users WHERE id NOT IN (SELECT user_id FROM blocks);
 ```
 
 ✅ Correct:
@@ -237,6 +244,8 @@ CREATE TABLE t (code TEXT CHECK (length(code) = 3));
 GRANT SELECT ON users TO reporting;
 REVOKE ALL ON users FROM PUBLIC;
 CREATE INDEX CONCURRENTLY idx_users_email ON users (email);
+SELECT id FROM users u WHERE NOT EXISTS (SELECT 1 FROM blocks b WHERE b.user_id = u.id);
+SELECT 1 FROM users WHERE id NOT IN (1, 2, 3); -- literal list is fine
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import noNaturalJoin from "./rules/no-natural-join.js";
 import noMoneyType from "./rules/no-money-type.js";
 import noCharType from "./rules/no-char-type.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
+import noNotInSubquery from "./rules/no-not-in-subquery.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -33,6 +34,7 @@ const plugin: ESLint.Plugin = {
     "no-money-type": noMoneyType,
     "no-char-type": noCharType,
     "no-grant-to-public": noGrantToPublic,
+    "no-not-in-subquery": noNotInSubquery,
     "no-syntax-error": noSyntaxError,
     "no-truncate-cascade": noTruncateCascade,
     "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -58,6 +60,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-money-type": "error",
         "postgresql/no-char-type": "warn",
         "postgresql/no-grant-to-public": "warn",
+        "postgresql/no-not-in-subquery": "error",
         "postgresql/no-syntax-error": "error",
         "postgresql/no-truncate-cascade": "warn",
         "postgresql/prefer-jsonb-over-json": "warn",

--- a/src/rules/no-not-in-subquery.ts
+++ b/src/rules/no-not-in-subquery.ts
@@ -1,0 +1,47 @@
+import type { Rule } from "eslint";
+
+const isNotInSubquery = (node: any): boolean => {
+  // The visitor key guarantees this is a BoolExpr; only check what
+  // distinguishes `NOT IN (subquery)` from other `NOT (...)` shapes.
+  if (node.boolop !== "NOT_EXPR") return false;
+  const args = Array.isArray(node.args) ? node.args : [];
+  if (args.length !== 1) return false;
+  const arg = args[0];
+  if (arg?.type !== "SubLink") return false;
+  if (arg.subLinkType !== "ANY_SUBLINK") return false;
+  // `NOT IN (subq)` parses without an explicit operName.
+  // `NOT (x = ANY(subq))` would set operName, so excluding it leaves only NOT IN.
+  if (arg.operName) return false;
+  // `NOT IN (subq)` always has a testexpr; rule out the rare bare-ANY form.
+  if (!arg.testexpr) return false;
+  return true;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `NOT IN (subquery)` because NULL values in the subquery silently return zero rows",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNotInSubquery:
+        "`NOT IN (subquery)` returns no rows if the subquery yields any NULL — almost certainly not what you want. Use `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` instead; it handles NULL correctly.",
+    },
+  },
+  create(context) {
+    return {
+      BoolExpr(node: any) {
+        if (isNotInSubquery(node)) {
+          context.report({ node, messageId: "noNotInSubquery" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-not-in-subquery/invalid/not-in-subquery-errors.expected.json
+++ b/tests/fixtures/no-not-in-subquery/invalid/not-in-subquery-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noNotInSubquery"
+  }
+]

--- a/tests/fixtures/no-not-in-subquery/invalid/not-in-subquery.sql
+++ b/tests/fixtures/no-not-in-subquery/invalid/not-in-subquery.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users WHERE id NOT IN (SELECT user_id FROM blocks) LIMIT 100;

--- a/tests/fixtures/no-not-in-subquery/valid/in-subquery.sql
+++ b/tests/fixtures/no-not-in-subquery/valid/in-subquery.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM users WHERE id IN (SELECT user_id FROM admins) LIMIT 100;

--- a/tests/fixtures/no-not-in-subquery/valid/not-exists.sql
+++ b/tests/fixtures/no-not-in-subquery/valid/not-exists.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users u WHERE NOT EXISTS (SELECT 1 FROM blocks b WHERE b.user_id = u.id) LIMIT 100;

--- a/tests/fixtures/no-not-in-subquery/valid/not-in-list.sql
+++ b/tests/fixtures/no-not-in-subquery/valid/not-in-list.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM users WHERE id NOT IN (1, 2, 3) LIMIT 100;

--- a/tests/no-not-in-subquery.test.ts
+++ b/tests/no-not-in-subquery.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-not-in-subquery.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-not-in-subquery", rule, "should disallow NOT IN (subquery)");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/no-not-in-subquery` that errors on `NOT IN (subquery)`. Enabled at `error` in `configs.recommended`. Literal `NOT IN (1, 2, 3)` lists are unaffected.

## Motivation

`NOT IN (subquery)` is the SQL gotcha that bites everyone exactly once: under three-valued logic, a single NULL in the subquery makes the predicate UNKNOWN, which `WHERE` treats as false, so the outer query returns zero rows. `NOT EXISTS (SELECT 1 FROM ... WHERE ...)` evaluates correctly under NULL. Literal lists parse to a different AST shape and are not flagged.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/no-not-in-subquery` (distinguishes `NOT IN (subq)` from `NOT IN (list)` and from `NOT (x = ANY(subq))` via the parser's `operName`).
- Wired into `configs.recommended` at `error`.
- README rule docs.
- Unit test + fixtures (covers `NOT EXISTS`, `NOT IN (list)`, `IN (subquery)` as valid).
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on rule in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->