### PR TITLE
feat: add postgresql/snake-case-table-name rule

### DIFF
--- a/.changeset/snake-case-table-name.md
+++ b/.changeset/snake-case-table-name.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/snake-case-table-name` rule: warns when a `CREATE TABLE` declares a table name that is not snake_case (typically a quoted mixed-case identifier). Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Warns on `char(n)` (a.k.a. `bpchar`) columns. PostgreSQL pads stored `char(n)` v
 Warns on `GRANT ... TO PUBLIC`. The PUBLIC pseudo-role covers every current and future role in the database, including ones added later for unrelated services or admin tooling. Privilege grants should name the role(s) explicitly. Note that `REVOKE ... FROM PUBLIC` is unaffected — revoking the implicit grants is good hygiene.
 
 **Type**: Problem  
+### `postgresql/snake-case-table-name`
+
+Warns when a `CREATE TABLE` declares a table name that is not snake_case (lowercase letters, digits, and underscores; must start with a letter). Quoted mixed-case identifiers (`"UserAccounts"`) preserve their case and force every caller to quote them — a steady source of `relation does not exist` errors. Unquoted `CamelCase` is silently lowercased by PostgreSQL, so it passes.
+
+**Type**: Suggestion  
 **Recommended**: ⚠️ Warn  
 **Fixable**: ❌ No
 
@@ -207,6 +212,7 @@ CREATE TABLE t (created_at TIMESTAMP);
 CREATE TABLE t (code CHAR(3));
 CREATE TABLE t (code BPCHAR(3));
 GRANT SELECT ON users TO PUBLIC;
+CREATE TABLE "UserAccounts" (id INT PRIMARY KEY);
 ```
 
 ✅ Correct:
@@ -246,6 +252,8 @@ REVOKE ALL ON users FROM PUBLIC;
 CREATE INDEX CONCURRENTLY idx_users_email ON users (email);
 SELECT id FROM users u WHERE NOT EXISTS (SELECT 1 FROM blocks b WHERE b.user_id = u.id);
 SELECT 1 FROM users WHERE id NOT IN (1, 2, 3); -- literal list is fine
+CREATE TABLE user_accounts (id INT PRIMARY KEY);
+CREATE TABLE UserAccounts (id INT PRIMARY KEY); -- folded to useraccounts
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import requireLimit from "./rules/require-limit.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
 import requirePrimaryKey from "./rules/require-primary-key.js";
+import snakeCaseTableName from "./rules/snake-case-table-name.js";
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -46,6 +47,7 @@ const plugin: ESLint.Plugin = {
     "require-where-in-delete": requireWhereInDelete,
     "require-where-in-update": requireWhereInUpdate,
     "require-primary-key": requirePrimaryKey,
+    "snake-case-table-name": snakeCaseTableName,
   },
   configs: {
     recommended: {
@@ -71,6 +73,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/require-where-in-delete": "error",
         "postgresql/require-where-in-update": "error",
         "postgresql/require-primary-key": "warn",
+        "postgresql/snake-case-table-name": "warn",
       },
     } satisfies Linter.Config,
   },

--- a/src/rules/snake-case-table-name.ts
+++ b/src/rules/snake-case-table-name.ts
@@ -1,0 +1,39 @@
+import type { Rule } from "eslint";
+
+const SNAKE_CASE = /^[a-z][a-z0-9_]*$/;
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Require table names to be snake_case",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      notSnakeCase:
+        'Table name `{{name}}` is not snake_case. PostgreSQL folds unquoted identifiers to lower case but preserves the case of quoted identifiers; mixing the two leads to `relation "BadName" does not exist` errors that are confusing to debug.',
+    },
+  },
+  create(context) {
+    const checkRelation = (relation: any, node: any) => {
+      const name = relation?.relname;
+      if (typeof name === "string" && !SNAKE_CASE.test(name)) {
+        context.report({
+          node,
+          messageId: "notSnakeCase",
+          data: { name },
+        });
+      }
+    };
+    return {
+      CreateStmt(node: any) {
+        checkRelation(node?.relation, node);
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/snake-case-table-name/invalid/quoted-camel-errors.expected.json
+++ b/tests/fixtures/snake-case-table-name/invalid/quoted-camel-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "notSnakeCase"
+  }
+]

--- a/tests/fixtures/snake-case-table-name/invalid/quoted-camel.sql
+++ b/tests/fixtures/snake-case-table-name/invalid/quoted-camel.sql
@@ -1,0 +1,1 @@
+CREATE TABLE "UserAccounts" (id INT PRIMARY KEY);

--- a/tests/fixtures/snake-case-table-name/valid/case-folded.sql
+++ b/tests/fixtures/snake-case-table-name/valid/case-folded.sql
@@ -1,0 +1,1 @@
+CREATE TABLE UserAccounts (id INT PRIMARY KEY);

--- a/tests/fixtures/snake-case-table-name/valid/snake.sql
+++ b/tests/fixtures/snake-case-table-name/valid/snake.sql
@@ -1,0 +1,1 @@
+CREATE TABLE user_accounts (id INT PRIMARY KEY);

--- a/tests/snake-case-table-name.test.ts
+++ b/tests/snake-case-table-name.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/snake-case-table-name.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "snake-case-table-name",
+  rule,
+  "should require snake_case table names",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/snake-case-table-name` that warns when a `CREATE TABLE` declares a non-snake_case name. Enabled at `warn` in `configs.recommended`.

## Motivation

PostgreSQL folds unquoted identifiers to lowercase. Unquoted `CamelCase` therefore silently becomes `camelcase` and round-trips fine. Quoted identifiers (`"UserAccounts"`) preserve their case and force every consumer to quote-match them, which is the source of "relation does not exist" confusion when one consumer forgets. Snake_case neutralizes both halves of the problem.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/snake-case-table-name` (applies to `CREATE TABLE`).
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->