### PR TITLE
feat: add postgresql/snake-case-column-name rule

### DIFF
--- a/.changeset/snake-case-column-name.md
+++ b/.changeset/snake-case-column-name.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/snake-case-column-name` rule: warns when a column declared in `CREATE TABLE` is not snake_case. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Warns on `GRANT ... TO PUBLIC`. The PUBLIC pseudo-role covers every current and 
 ### `postgresql/snake-case-table-name`
 
 Warns when a `CREATE TABLE` declares a table name that is not snake_case (lowercase letters, digits, and underscores; must start with a letter). Quoted mixed-case identifiers (`"UserAccounts"`) preserve their case and force every caller to quote them — a steady source of `relation does not exist` errors. Unquoted `CamelCase` is silently lowercased by PostgreSQL, so it passes.
+### `postgresql/snake-case-column-name`
+
+Warns when a column declared in `CREATE TABLE` is not snake_case. Same rationale as `snake-case-table-name`: PostgreSQL preserves the case of quoted identifiers, so a quoted `"CamelCol"` forces every consumer to quote-match the name, while unquoted `CamelCol` silently lowercases to `camelcol` and passes.
 
 **Type**: Suggestion  
 **Recommended**: ⚠️ Warn  
@@ -213,6 +216,7 @@ CREATE TABLE t (code CHAR(3));
 CREATE TABLE t (code BPCHAR(3));
 GRANT SELECT ON users TO PUBLIC;
 CREATE TABLE "UserAccounts" (id INT PRIMARY KEY);
+CREATE TABLE t ("CamelCol" INT);
 ```
 
 ✅ Correct:
@@ -254,6 +258,8 @@ SELECT id FROM users u WHERE NOT EXISTS (SELECT 1 FROM blocks b WHERE b.user_id 
 SELECT 1 FROM users WHERE id NOT IN (1, 2, 3); -- literal list is fine
 CREATE TABLE user_accounts (id INT PRIMARY KEY);
 CREATE TABLE UserAccounts (id INT PRIMARY KEY); -- folded to useraccounts
+CREATE TABLE t (camel_col INT);
+CREATE TABLE t (CamelCol INT); -- folded to camelcol
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
 import requirePrimaryKey from "./rules/require-primary-key.js";
 import snakeCaseTableName from "./rules/snake-case-table-name.js";
+import snakeCaseColumnName from "./rules/snake-case-column-name.js";
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -48,6 +49,7 @@ const plugin: ESLint.Plugin = {
     "require-where-in-update": requireWhereInUpdate,
     "require-primary-key": requirePrimaryKey,
     "snake-case-table-name": snakeCaseTableName,
+    "snake-case-column-name": snakeCaseColumnName,
   },
   configs: {
     recommended: {
@@ -74,6 +76,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/require-where-in-update": "error",
         "postgresql/require-primary-key": "warn",
         "postgresql/snake-case-table-name": "warn",
+        "postgresql/snake-case-column-name": "warn",
       },
     } satisfies Linter.Config,
   },

--- a/src/rules/snake-case-column-name.ts
+++ b/src/rules/snake-case-column-name.ts
@@ -1,0 +1,36 @@
+import type { Rule } from "eslint";
+
+const SNAKE_CASE = /^[a-z][a-z0-9_]*$/;
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Require column names to be snake_case",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      notSnakeCase:
+        "Column name `{{name}}` is not snake_case. PostgreSQL preserves the case of quoted identifiers; using a mixed-case quoted name forces every consumer to quote-match it.",
+    },
+  },
+  create(context) {
+    return {
+      ColumnDef(node: any) {
+        const name = node?.colname;
+        if (typeof name === "string" && !SNAKE_CASE.test(name)) {
+          context.report({
+            node,
+            messageId: "notSnakeCase",
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/snake-case-column-name/invalid/quoted-camel-errors.expected.json
+++ b/tests/fixtures/snake-case-column-name/invalid/quoted-camel-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "notSnakeCase"
+  }
+]

--- a/tests/fixtures/snake-case-column-name/invalid/quoted-camel.sql
+++ b/tests/fixtures/snake-case-column-name/invalid/quoted-camel.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t ("CamelCol" INT);

--- a/tests/fixtures/snake-case-column-name/valid/case-folded.sql
+++ b/tests/fixtures/snake-case-column-name/valid/case-folded.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (CamelCol INT);

--- a/tests/fixtures/snake-case-column-name/valid/snake.sql
+++ b/tests/fixtures/snake-case-column-name/valid/snake.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t (id INT PRIMARY KEY, created_at TIMESTAMPTZ);

--- a/tests/snake-case-column-name.test.ts
+++ b/tests/snake-case-column-name.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/snake-case-column-name.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "snake-case-column-name",
+  rule,
+  "should require snake_case column names",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/snake-case-column-name` that warns when a column declared in `CREATE TABLE` is not snake_case. Enabled at `warn` in `configs.recommended`.

## Motivation

Sibling rule to `snake-case-table-name`. Quoted mixed-case columns (`"CamelCol"`) keep their case and require every consumer to quote them, which is a major source of `column "..." does not exist` confusion. Unquoted `CamelCol` is silently lowercased and passes.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/snake-case-column-name` (visits `ColumnDef`).
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->