### PR TITLE
feat: add postgresql/no-implicit-join rule

### DIFF
--- a/.changeset/no-implicit-join.md
+++ b/.changeset/no-implicit-join.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-implicit-join` rule: warns on comma-separated `FROM` clauses and recommends explicit `JOIN ... ON ...`. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Warns when a `CREATE TABLE` declares a table name that is not snake_case (lowerc
 ### `postgresql/snake-case-column-name`
 
 Warns when a column declared in `CREATE TABLE` is not snake_case. Same rationale as `snake-case-table-name`: PostgreSQL preserves the case of quoted identifiers, so a quoted `"CamelCol"` forces every consumer to quote-match the name, while unquoted `CamelCol` silently lowercases to `camelcol` and passes.
+### `postgresql/no-implicit-join`
+
+Warns on `SELECT ... FROM a, b WHERE ...` style implicit joins. Comma syntax is an implicit cross join whose join condition is buried in `WHERE`; forgetting the condition silently produces a cartesian product. Explicit `JOIN ... ON ...` puts the join condition next to the join.
 
 **Type**: Suggestion  
 **Recommended**: ⚠️ Warn  
@@ -217,6 +220,7 @@ CREATE TABLE t (code BPCHAR(3));
 GRANT SELECT ON users TO PUBLIC;
 CREATE TABLE "UserAccounts" (id INT PRIMARY KEY);
 CREATE TABLE t ("CamelCol" INT);
+SELECT a.id FROM a, b WHERE a.id = b.id;
 ```
 
 ✅ Correct:
@@ -260,6 +264,7 @@ CREATE TABLE user_accounts (id INT PRIMARY KEY);
 CREATE TABLE UserAccounts (id INT PRIMARY KEY); -- folded to useraccounts
 CREATE TABLE t (camel_col INT);
 CREATE TABLE t (CamelCol INT); -- folded to camelcol
+SELECT a.id FROM a JOIN b ON a.id = b.id;
 ```
 
 ### `postgresql/require-limit`

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import noMoneyType from "./rules/no-money-type.js";
 import noCharType from "./rules/no-char-type.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noNotInSubquery from "./rules/no-not-in-subquery.js";
+import noImplicitJoin from "./rules/no-implicit-join.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -37,6 +38,7 @@ const plugin: ESLint.Plugin = {
     "no-char-type": noCharType,
     "no-grant-to-public": noGrantToPublic,
     "no-not-in-subquery": noNotInSubquery,
+    "no-implicit-join": noImplicitJoin,
     "no-syntax-error": noSyntaxError,
     "no-truncate-cascade": noTruncateCascade,
     "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -65,6 +67,7 @@ const plugin: ESLint.Plugin = {
         "postgresql/no-char-type": "warn",
         "postgresql/no-grant-to-public": "warn",
         "postgresql/no-not-in-subquery": "error",
+        "postgresql/no-implicit-join": "warn",
         "postgresql/no-syntax-error": "error",
         "postgresql/no-truncate-cascade": "warn",
         "postgresql/prefer-jsonb-over-json": "warn",

--- a/src/rules/no-implicit-join.ts
+++ b/src/rules/no-implicit-join.ts
@@ -1,0 +1,33 @@
+import type { Rule } from "eslint";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow comma-separated FROM clauses (implicit cross joins); use explicit JOIN syntax",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noImplicitJoin:
+        "Comma-separated tables in `FROM` are an implicit cross join. Use explicit `JOIN ... ON ...` so the join condition lives next to the join.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: any) {
+        const fromClause = Array.isArray(node?.fromClause)
+          ? node.fromClause
+          : [];
+        if (fromClause.length > 1) {
+          context.report({ node, messageId: "noImplicitJoin" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-implicit-join/invalid/comma-join-errors.expected.json
+++ b/tests/fixtures/no-implicit-join/invalid/comma-join-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noImplicitJoin"
+  }
+]

--- a/tests/fixtures/no-implicit-join/invalid/comma-join.sql
+++ b/tests/fixtures/no-implicit-join/invalid/comma-join.sql
@@ -1,0 +1,1 @@
+SELECT a.id FROM a, b WHERE a.id = b.id;

--- a/tests/fixtures/no-implicit-join/valid/explicit-join.sql
+++ b/tests/fixtures/no-implicit-join/valid/explicit-join.sql
@@ -1,0 +1,1 @@
+SELECT a.id FROM a JOIN b ON a.id = b.id;

--- a/tests/fixtures/no-implicit-join/valid/single-table.sql
+++ b/tests/fixtures/no-implicit-join/valid/single-table.sql
@@ -1,0 +1,1 @@
+SELECT id FROM a;

--- a/tests/no-implicit-join.test.ts
+++ b/tests/no-implicit-join.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-implicit-join.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-implicit-join", rule, "should disallow comma-separated FROM");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

New rule `postgresql/no-implicit-join` that warns on `SELECT ... FROM a, b WHERE ...` style joins. Enabled at `warn` in `configs.recommended`.

## Motivation

The comma in `FROM a, b` is an implicit cross join. The actual join condition lives in `WHERE`, which means deleting that condition silently produces a cartesian product — a real production-incident class. Explicit `JOIN ... ON ...` puts the join condition next to the join, where it cannot be forgotten without an obvious diff.

## Stacked on #60

Branches off `chore/oss-scaffolding` (#60). Merge #60 first.

## Changes

- New rule `postgresql/no-implicit-join`.
- Wired into `configs.recommended` at `warn`.
- README rule docs.
- Unit test + fixtures.
- Changeset (`minor`).

## Testing

`pnpm check:all` and `pnpm test` pass locally.

## Breaking changes

New default-on warning in `configs.recommended` (pre-1.0). Flagged in the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->