### PR TITLE
docs: restore postgresql/no-select-star README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ SELECT * FROM WHERE id = 1;
 SELECT * FROM users WHERE id = 1;
 ```
 
+### `postgresql/no-select-star`
+
+Disallows `SELECT *` (and `<alias>.*`). Listing columns explicitly keeps result schemas stable when the underlying table evolves and avoids accidentally pulling new sensitive columns into a query.
+
+**Type**: Suggestion  
+**Recommended**: ❌ Off by default  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT * FROM users;
+SELECT u.* FROM users u;
+```
+
+✅ Correct:
+
+```sql
+SELECT id, name FROM users;
+SELECT count(*) FROM users; -- aggregate star is fine
+```
+
 ### `postgresql/require-where-in-delete`
 
 Errors on `DELETE` statements that have no `WHERE` clause — deleting every row in a table is almost always a mistake. Use `TRUNCATE` if you really mean to empty the table.


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Restore the `postgresql/no-select-star` README section that was inadvertently dropped when #62 (`require-where-in-delete`) was rebased onto main with a too-aggressive conflict resolution. The rule itself remains registered in `src/index.ts` and works — only the docs were missing.

## Motivation

Without the README section, users would land on `postgresql/no-select-star` from the rule listing and find no documentation.

## Changes

- README: re-add the `postgresql/no-select-star` section (Examples + metadata).

## Testing

`pnpm check:all` passes locally. No code changes — README only.

## Breaking changes

None.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (n/a — docs only).
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->