### PR TITLE
fix: bind the plugin in configs.recommended

### DIFF
--- a/.changeset/configs-recommended-plugins.md
+++ b/.changeset/configs-recommended-plugins.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+`configs.recommended` now includes a `plugins: { postgresql }` field. Spreading `...postgresql.configs.recommended` in a flat ESLint config now binds the plugin automatically, so consumers no longer have to add `plugins: { postgresql }` separately for the rule severities to resolve. The README example continues to work as written.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,88 +1,97 @@
 import type { ESLint, Linter } from "eslint";
 import postgresqlParser from "postgresql-eslint-parser";
 import { name, version } from "./meta.js";
-import noSelectStar from "./rules/no-select-star.js";
-import noDropTableCascade from "./rules/no-drop-table-cascade.js";
-import noCrossJoin from "./rules/no-cross-join.js";
-import noNaturalJoin from "./rules/no-natural-join.js";
-import noMoneyType from "./rules/no-money-type.js";
 import noCharType from "./rules/no-char-type.js";
+import noCrossJoin from "./rules/no-cross-join.js";
+import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
-import noNotInSubquery from "./rules/no-not-in-subquery.js";
 import noImplicitJoin from "./rules/no-implicit-join.js";
+import noMoneyType from "./rules/no-money-type.js";
+import noNaturalJoin from "./rules/no-natural-join.js";
+import noNotInSubquery from "./rules/no-not-in-subquery.js";
+import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
-import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
+import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
+import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
 import preferTextOverVarchar from "./rules/prefer-text-over-varchar.js";
 import preferTimestamptz from "./rules/prefer-timestamptz.js";
-import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import requireLimit from "./rules/require-limit.js";
+import requirePrimaryKey from "./rules/require-primary-key.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
-import requirePrimaryKey from "./rules/require-primary-key.js";
-import snakeCaseTableName from "./rules/snake-case-table-name.js";
 import snakeCaseColumnName from "./rules/snake-case-column-name.js";
+import snakeCaseTableName from "./rules/snake-case-table-name.js";
+
+const rules = {
+  "no-char-type": noCharType,
+  "no-cross-join": noCrossJoin,
+  "no-drop-table-cascade": noDropTableCascade,
+  "no-grant-to-public": noGrantToPublic,
+  "no-implicit-join": noImplicitJoin,
+  "no-money-type": noMoneyType,
+  "no-natural-join": noNaturalJoin,
+  "no-not-in-subquery": noNotInSubquery,
+  "no-select-star": noSelectStar,
+  "no-syntax-error": noSyntaxError,
+  "no-truncate-cascade": noTruncateCascade,
+  "prefer-create-index-concurrently": preferCreateIndexConcurrently,
+  "prefer-identity-over-serial": preferIdentityOverSerial,
+  "prefer-jsonb-over-json": preferJsonbOverJson,
+  "prefer-text-over-varchar": preferTextOverVarchar,
+  "prefer-timestamptz": preferTimestamptz,
+  "require-limit": requireLimit,
+  "require-primary-key": requirePrimaryKey,
+  "require-where-in-delete": requireWhereInDelete,
+  "require-where-in-update": requireWhereInUpdate,
+  "snake-case-column-name": snakeCaseColumnName,
+  "snake-case-table-name": snakeCaseTableName,
+};
 
 const plugin: ESLint.Plugin = {
   meta: {
     name,
     version,
   },
-  rules: {
-    "no-select-star": noSelectStar,
-    "no-drop-table-cascade": noDropTableCascade,
-    "no-cross-join": noCrossJoin,
-    "no-natural-join": noNaturalJoin,
-    "no-money-type": noMoneyType,
-    "no-char-type": noCharType,
-    "no-grant-to-public": noGrantToPublic,
-    "no-not-in-subquery": noNotInSubquery,
-    "no-implicit-join": noImplicitJoin,
-    "no-syntax-error": noSyntaxError,
-    "no-truncate-cascade": noTruncateCascade,
-    "prefer-jsonb-over-json": preferJsonbOverJson,
-    "prefer-identity-over-serial": preferIdentityOverSerial,
-    "prefer-text-over-varchar": preferTextOverVarchar,
-    "prefer-timestamptz": preferTimestamptz,
-    "prefer-create-index-concurrently": preferCreateIndexConcurrently,
-    "require-limit": requireLimit,
-    "require-where-in-delete": requireWhereInDelete,
-    "require-where-in-update": requireWhereInUpdate,
-    "require-primary-key": requirePrimaryKey,
-    "snake-case-table-name": snakeCaseTableName,
-    "snake-case-column-name": snakeCaseColumnName,
-  },
-  configs: {
-    recommended: {
-      files: ["**/*.sql"],
-      languageOptions: {
-        parser: postgresqlParser,
-      },
-      rules: {
-        "postgresql/no-drop-table-cascade": "warn",
-        "postgresql/no-cross-join": "warn",
-        "postgresql/no-natural-join": "error",
-        "postgresql/no-money-type": "error",
-        "postgresql/no-char-type": "warn",
-        "postgresql/no-grant-to-public": "warn",
-        "postgresql/no-not-in-subquery": "error",
-        "postgresql/no-implicit-join": "warn",
-        "postgresql/no-syntax-error": "error",
-        "postgresql/no-truncate-cascade": "warn",
-        "postgresql/prefer-jsonb-over-json": "warn",
-        "postgresql/prefer-identity-over-serial": "warn",
-        "postgresql/prefer-text-over-varchar": "warn",
-        "postgresql/prefer-timestamptz": "warn",
-        "postgresql/require-limit": "warn",
-        "postgresql/require-where-in-delete": "error",
-        "postgresql/require-where-in-update": "error",
-        "postgresql/require-primary-key": "warn",
-        "postgresql/snake-case-table-name": "warn",
-        "postgresql/snake-case-column-name": "warn",
-      },
-    } satisfies Linter.Config,
-  },
+  rules,
+};
+
+// `configs.recommended` references the plugin object itself in `plugins`, so
+// we set it after the plugin is constructed to avoid the circular literal.
+// Spreading `...postgresql.configs.recommended` in a flat-config array now
+// gives ESLint everything it needs (parser, plugin binding, rule severities)
+// without the consumer having to wire the plugin separately.
+plugin.configs = {
+  recommended: {
+    files: ["**/*.sql"],
+    plugins: { postgresql: plugin },
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: {
+      "postgresql/no-char-type": "warn",
+      "postgresql/no-cross-join": "warn",
+      "postgresql/no-drop-table-cascade": "warn",
+      "postgresql/no-grant-to-public": "warn",
+      "postgresql/no-implicit-join": "warn",
+      "postgresql/no-money-type": "error",
+      "postgresql/no-natural-join": "error",
+      "postgresql/no-not-in-subquery": "error",
+      "postgresql/no-syntax-error": "error",
+      "postgresql/no-truncate-cascade": "warn",
+      "postgresql/prefer-identity-over-serial": "warn",
+      "postgresql/prefer-jsonb-over-json": "warn",
+      "postgresql/prefer-text-over-varchar": "warn",
+      "postgresql/prefer-timestamptz": "warn",
+      "postgresql/require-limit": "warn",
+      "postgresql/require-primary-key": "warn",
+      "postgresql/require-where-in-delete": "error",
+      "postgresql/require-where-in-update": "error",
+      "postgresql/snake-case-column-name": "warn",
+      "postgresql/snake-case-table-name": "warn",
+    },
+  } satisfies Linter.Config,
 };
 
 export default plugin;


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

\`configs.recommended\` now includes a \`plugins: { postgresql }\` binding so the README usage (\`...postgresql.configs.recommended\`) actually resolves the rule namespace. Without this, every rule errored as \"unknown\" unless the consumer wired the plugin themselves.

## Motivation

ESLint flat config requires every config object that references rules under a plugin namespace to declare that plugin in its own \`plugins\` map. The shipped preset was missing the binding (raised as a review comment on #74).

The fix was deferred from the rule PRs because it touches \`src/index.ts\` shape and would conflict 20 ways across those PRs.

## Changes

- \`src/index.ts\`: assign \`plugin.configs\` after the plugin object is constructed so the recommended config can reference \`plugin\` itself in its \`plugins\` map.
- Normalised import / rules / recommended ordering to alphabetical.
- Changeset (\`minor\`).

## Testing

\`pnpm check:all\` and \`pnpm test\` pass locally. The plugin smoke test (\`tests/index.test.ts\`) and every rule test continue to pass.

## Breaking changes

None — additive. Spreading the preset before this change required a manual \`plugins: { postgresql }\` next to it; that manual binding remains valid (ESLint flat config allows the same plugin to be declared in multiple config objects).

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (existing tests still cover the registered-rules surface).
- [x] I have added or updated documentation where user-visible behavior changed (no README change needed; the existing example was already correct).
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->