### PR TITLE
test: convert plugin smoke test to a generic invariant check

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,29 +1,55 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import plugin from "../src/index.js";
 
 describe("eslint-plugin-postgresql", () => {
-  it("should export plugin", () => {
+  it("exports a plugin object", () => {
     expect(plugin).toBeDefined();
     expect(typeof plugin).toBe("object");
   });
 
-  it("should have meta information", () => {
-    expect(plugin.meta).toBeDefined();
-    if (plugin.meta) {
-      expect(plugin.meta.name).toBe("eslint-plugin-postgresql");
-      expect(plugin.meta.version).toBeDefined();
-    }
+  it("has a complete meta block", () => {
+    expect(plugin.meta?.name).toBe("eslint-plugin-postgresql");
+    expect(typeof plugin.meta?.version).toBe("string");
   });
 
-  it("should have rules", () => {
+  it("registers at least one rule and every registered rule is well-formed", () => {
     expect(plugin.rules).toBeDefined();
-    if (plugin.rules) {
-      expect(plugin.rules["no-syntax-error"]).toBeDefined();
-      expect(plugin.rules["require-limit"]).toBeDefined();
+    const entries = Object.entries(plugin.rules ?? {});
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [name, rule] of entries) {
+      expect(rule, `${name} should be a rule object`).toBeDefined();
+      const meta = (rule as { meta?: unknown }).meta;
+      expect(meta, `${name} is missing meta`).toBeDefined();
+      const create = (rule as { create?: unknown }).create;
+      expect(typeof create, `${name} is missing create()`).toBe("function");
     }
   });
 
-  it("should have configs", () => {
-    expect(plugin.configs).toBeDefined();
+  it("ships configs.recommended that binds the plugin and references real rules", () => {
+    const recommended = plugin.configs?.["recommended"];
+    expect(recommended).toBeDefined();
+    if (!recommended || typeof recommended !== "object") return;
+
+    // Plugin must be bound under the `postgresql` namespace so the rule
+    // severities below resolve.
+    const plugins = (recommended as { plugins?: Record<string, unknown> })
+      .plugins;
+    expect(plugins?.["postgresql"]).toBe(plugin);
+
+    // Every rule severity in `recommended` must reference a rule that
+    // actually exists in `plugin.rules`. This catches the drift class
+    // where a recommended-config entry points at a typo or removed rule.
+    const rules = (recommended as { rules?: Record<string, unknown> }).rules;
+    expect(rules).toBeDefined();
+    for (const key of Object.keys(rules ?? {})) {
+      expect(key.startsWith("postgresql/"), `${key} missing namespace`).toBe(
+        true,
+      );
+      const ruleName = key.slice("postgresql/".length);
+      expect(
+        plugin.rules?.[ruleName],
+        `recommended references unknown rule "${ruleName}"`,
+      ).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Rewrite \`tests/index.test.ts\` so it asserts general invariants over the plugin export instead of hand-listing two specific rule names. Catches the drift class where \`configs.recommended\` references a rule that doesn't exist (typo or removed rule).

## Motivation

The old smoke test only checked \`no-syntax-error\` and \`require-limit\` existed. As 20 new rules landed, the test was unaware of any of them, and adding hand-listed assertions per rule PR created 20-way merge conflicts in the same file. Multiple reviewers flagged this on the rule PRs.

## Changes

- Iterate over every rule in \`plugin.rules\` and assert each has \`meta\` and \`create()\`.
- Assert \`configs.recommended.plugins.postgresql === plugin\`.
- Assert every severity key in \`configs.recommended.rules\` resolves to a registered rule.

## Testing

\`pnpm test\` passes (26 tests). \`pnpm check:all\` passes.

## Breaking changes

None — test-only change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed (n/a — internal test).
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->