### PR TITLE
chore: pin pnpm via packageManager, fix SECURITY link, align CLAUDE testing docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js 24
         uses: actions/setup-node@v4
@@ -60,8 +58,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
@@ -89,8 +85,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js 24
         uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,15 +181,18 @@ fixability.
 
 ### Tests
 
-Two layers:
+The repo's pattern is **fixture-driven**: each rule has a single test file
+that wires the fixture loader.
 
-1. **`tests/<rule>.test.ts`** — RuleTester-style cases with inline SQL strings
-   for the canonical happy path and a few edge cases.
-2. **`tests/fixtures/<rule>/`** — larger SQL fixtures snapshot-tested against
-   the rule's output. Regenerate with `pnpm update-fixtures` when the change
-   is intentional, and review the diff carefully before committing.
+1. **`tests/<rule>.test.ts`** — one-line file that calls
+   `runRuleTest("<rule>", rule, "<description>")`; the helper auto-loads
+   every `.sql` file under `tests/fixtures/<rule>/{valid,invalid}/`.
+2. **`tests/fixtures/<rule>/valid/*.sql`** — SQL the rule must accept.
+3. **`tests/fixtures/<rule>/invalid/*.sql`** — SQL the rule must flag, paired
+   with `<basename>-errors.expected.json` listing the expected `messageId`s
+   (and optional positions).
 
-A bug fix must include a fixture that fails on the parent commit.
+A bug fix must include a new invalid fixture that fails on the parent commit.
 
 ## Public API is a contract
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,9 @@
 **Do not file a public GitHub issue for security bugs.**
 
 Please report security issues privately via [GitHub's Private Vulnerability
-Reporting](../../security/advisories/new). The maintainer will acknowledge
-within a reasonable timeframe and coordinate a fix and disclosure.
+Reporting](https://github.com/baseballyama/eslint-plugin-postgresql/security/advisories/new).
+The maintainer will acknowledge within a reasonable timeframe and coordinate
+a fix and disclosure.
 
 Examples of issues in scope:
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "eslint-plugin-postgresql",
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@10.25.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Three small follow-ups raised on the rule PRs, batched together because each is one or two lines.

## Motivation

- Reviewers asked for a \`packageManager\` field to keep contributor environments aligned with CI (raised on #75).
- The \`SECURITY.md\` reporting link was a relative path, which breaks anywhere the file is re-rendered outside the repo root (raised on #72, #73, #78).
- The \`CLAUDE.md\` testing guidance described an \"inline RuleTester strings\" pattern that does not match the fixture-driven pattern every rule actually uses (raised on #71).

## Changes

- \`package.json\`: add \`packageManager: pnpm@10.25.0\`.
- \`.github/workflows/ci.yml\`, \`.github/workflows/release.yml\`: drop the explicit \`version: 10\` from \`pnpm/action-setup\` since the action now picks up the \`packageManager\` field.
- \`SECURITY.md\`: replace the relative reporting link with an absolute repo URL.
- \`CLAUDE.md\` (Tests section): describe the \`runRuleTest(...)\` + \`tests/fixtures/<rule>/{valid,invalid}/\` layout the rules already use.

## Testing

\`pnpm check:all\` and \`pnpm test\` pass locally.

## Breaking changes

None — repo-tooling and docs only.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (n/a — repo plumbing / docs).
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->