### PR TITLE
refactor: type rule visitor parameters with the parser AST instead of `any`

### DIFF
--- a/src/rules/no-char-type.ts
+++ b/src/rules/no-char-type.ts
@@ -1,18 +1,6 @@
 import type { Rule } from "eslint";
-
-const getTypeName = (typeName: any): string | undefined => {
-  if (!typeName || typeof typeName !== "object") return undefined;
-  // typeName carries the qualified name across numeric-string keys "0", "1", ...
-  // The unqualified type name is at the highest-numbered segment; lower
-  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
-  // segment-1 name when present so `public.varchar` still resolves to
-  // `varchar` and not the schema.
-  const v1 = typeName["1"]?.sval;
-  if (typeof v1 === "string") return v1;
-  const v0 = typeName["0"]?.sval;
-  if (typeof v0 === "string") return v0;
-  return undefined;
-};
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -31,10 +19,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      ColumnDef(node: any) {
-        const t = getTypeName(node?.typeName);
-        if (t === "bpchar") {
-          context.report({ node, messageId: "noChar" });
+      ColumnDef(node: Ast.ColumnDef) {
+        if (getTypeName(node.typeName) === "bpchar") {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noChar",
+          });
         }
       },
     };

--- a/src/rules/no-cross-join.ts
+++ b/src/rules/no-cross-join.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -17,14 +18,17 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      JoinExpr(node: any) {
+      JoinExpr(node: Ast.JoinExpr) {
         const isCrossJoin =
           node.jointype === "JOIN_INNER" &&
           !node.quals &&
           !node.usingClause &&
           !node.isNatural;
         if (isCrossJoin) {
-          context.report({ node, messageId: "noCrossJoin" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noCrossJoin",
+          });
         }
       },
     };

--- a/src/rules/no-drop-table-cascade.ts
+++ b/src/rules/no-drop-table-cascade.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -18,7 +19,7 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      DropStmt(node: any) {
+      DropStmt(node: Ast.DropStmt) {
         // Scope to DROP TABLE only — the rule name promises that. Other DROP
         // ... CASCADE variants (schema, type, etc.) can be added as separate
         // rules if needed.
@@ -26,7 +27,10 @@ const rule: Rule.RuleModule = {
           node.behavior === "DROP_CASCADE" &&
           node.removeType === "OBJECT_TABLE"
         ) {
-          context.report({ node, messageId: "noCascade" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noCascade",
+          });
         }
       },
     };

--- a/src/rules/no-grant-to-public.ts
+++ b/src/rules/no-grant-to-public.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -18,12 +19,22 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      GrantStmt(node: any) {
+      GrantStmt(node: Ast.GrantStmt) {
         if (!node.is_grant) return;
-        const grantees = Array.isArray(node.grantees) ? node.grantees : [];
+        // `grantees` is not in the upstream `GrantStmt` interface; the index
+        // signature on the parser type lets us reach it without `any`.
+        const grantees = node["grantees"];
+        if (!Array.isArray(grantees)) return;
         for (const g of grantees) {
-          if (g?.roletype === "ROLESPEC_PUBLIC") {
-            context.report({ node, messageId: "noPublic" });
+          if (
+            g != null &&
+            typeof g === "object" &&
+            (g as { roletype?: unknown }).roletype === "ROLESPEC_PUBLIC"
+          ) {
+            context.report({
+              node: node as unknown as Rule.Node,
+              messageId: "noPublic",
+            });
             return;
           }
         }

--- a/src/rules/no-implicit-join.ts
+++ b/src/rules/no-implicit-join.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -18,12 +19,13 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      SelectStmt(node: any) {
-        const fromClause = Array.isArray(node?.fromClause)
-          ? node.fromClause
-          : [];
-        if (fromClause.length > 1) {
-          context.report({ node, messageId: "noImplicitJoin" });
+      SelectStmt(node: Ast.SelectStmt) {
+        const fromClause = node.fromClause;
+        if (Array.isArray(fromClause) && fromClause.length > 1) {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noImplicitJoin",
+          });
         }
       },
     };

--- a/src/rules/no-money-type.ts
+++ b/src/rules/no-money-type.ts
@@ -1,18 +1,6 @@
 import type { Rule } from "eslint";
-
-const getTypeName = (typeName: any): string | undefined => {
-  if (!typeName || typeof typeName !== "object") return undefined;
-  // typeName carries the qualified name across numeric-string keys "0", "1", ...
-  // The unqualified type name is at the highest-numbered segment; lower
-  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
-  // segment-1 name when present so `public.varchar` still resolves to
-  // `varchar` and not the schema.
-  const v1 = typeName["1"]?.sval;
-  if (typeof v1 === "string") return v1;
-  const v0 = typeName["0"]?.sval;
-  if (typeof v0 === "string") return v0;
-  return undefined;
-};
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -31,10 +19,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      ColumnDef(node: any) {
-        const t = getTypeName(node?.typeName);
-        if (t === "money") {
-          context.report({ node, messageId: "noMoney" });
+      ColumnDef(node: Ast.ColumnDef) {
+        if (getTypeName(node.typeName) === "money") {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noMoney",
+          });
         }
       },
     };

--- a/src/rules/no-natural-join.ts
+++ b/src/rules/no-natural-join.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -17,9 +18,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      JoinExpr(node: any) {
+      JoinExpr(node: Ast.JoinExpr) {
         if (node.isNatural) {
-          context.report({ node, messageId: "noNaturalJoin" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noNaturalJoin",
+          });
         }
       },
     };

--- a/src/rules/no-not-in-subquery.ts
+++ b/src/rules/no-not-in-subquery.ts
@@ -1,13 +1,15 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { isSubLink } from "../utils/ast.js";
 
-const isNotInSubquery = (node: any): boolean => {
+const isNotInSubquery = (node: Ast.BoolExprPG): boolean => {
   // The visitor key guarantees this is a BoolExpr; only check what
   // distinguishes `NOT IN (subquery)` from other `NOT (...)` shapes.
   if (node.boolop !== "NOT_EXPR") return false;
-  const args = Array.isArray(node.args) ? node.args : [];
-  if (args.length !== 1) return false;
+  const args = node.args;
+  if (!Array.isArray(args) || args.length !== 1) return false;
   const arg = args[0];
-  if (arg?.type !== "SubLink") return false;
+  if (!isSubLink(arg)) return false;
   if (arg.subLinkType !== "ANY_SUBLINK") return false;
   // `NOT IN (subq)` parses without an explicit operName.
   // `NOT (x = ANY(subq))` would set operName, so excluding it leaves only NOT IN.
@@ -35,9 +37,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      BoolExpr(node: any) {
+      BoolExpr(node: Ast.BoolExprPG) {
         if (isNotInSubquery(node)) {
-          context.report({ node, messageId: "noNotInSubquery" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noNotInSubquery",
+          });
         }
       },
     };

--- a/src/rules/no-select-star.ts
+++ b/src/rules/no-select-star.ts
@@ -1,4 +1,6 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { isAStar, isColumnRef, isResTarget } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -18,18 +20,18 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      SelectStmt(node: any) {
+      SelectStmt(node: Ast.SelectStmt) {
         const targetList = node.targetList;
         if (!Array.isArray(targetList)) return;
         for (const target of targetList) {
-          const val = target?.val;
-          if (
-            val &&
-            val.type === "ColumnRef" &&
-            Array.isArray(val.fields) &&
-            val.fields.some((f: any) => f && f.type === "A_Star")
-          ) {
-            context.report({ node: target, messageId: "noSelectStar" });
+          if (!isResTarget(target)) continue;
+          const val = target.val;
+          if (!isColumnRef(val)) continue;
+          if (val.fields.some(isAStar)) {
+            context.report({
+              node: target as unknown as Rule.Node,
+              messageId: "noSelectStar",
+            });
           }
         }
       },

--- a/src/rules/no-syntax-error.ts
+++ b/src/rules/no-syntax-error.ts
@@ -1,9 +1,5 @@
 import type { Rule } from "eslint";
 
-// NOTE: Currently using basic syntax validation due to module loading issues with postgresql-eslint-parser
-// TODO: Replace with proper postgresql-eslint-parser when the libpg-query import issue is resolved
-// import postgresqlParser from "postgresql-eslint-parser";
-
 const rule: Rule.RuleModule = {
   meta: {
     type: "problem",
@@ -20,12 +16,25 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      Program(node: any) {
-        for (const stmt of node.body) {
-          if (stmt.type === "SQLParseError") {
-            const errorMessage = stmt.error || "Unknown SQL parsing error";
+      // The parser's Program node carries SQLStatementNode | SQLParseError
+      // children, but ESLint's visitor type is the estree Program. Accept the
+      // ESLint shape and re-narrow each statement individually.
+      Program(node) {
+        const body = (node as { body?: unknown }).body;
+        if (!Array.isArray(body)) return;
+        for (const stmt of body) {
+          if (
+            stmt != null &&
+            typeof stmt === "object" &&
+            (stmt as { type?: unknown }).type === "SQLParseError"
+          ) {
+            const parseError = stmt as { error?: unknown };
+            const errorMessage =
+              typeof parseError.error === "string"
+                ? parseError.error
+                : "Unknown SQL parsing error";
             context.report({
-              node: stmt,
+              node: stmt as unknown as Rule.Node,
               messageId: "syntaxError",
               data: { message: errorMessage },
             });

--- a/src/rules/no-truncate-cascade.ts
+++ b/src/rules/no-truncate-cascade.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { TruncateStmt } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -18,9 +19,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      TruncateStmt(node: any) {
+      TruncateStmt(node: TruncateStmt) {
         if (node.behavior === "DROP_CASCADE") {
-          context.report({ node, messageId: "noCascade" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "noCascade",
+          });
         }
       },
     };

--- a/src/rules/prefer-create-index-concurrently.ts
+++ b/src/rules/prefer-create-index-concurrently.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -18,9 +19,13 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      IndexStmt(node: any) {
-        if (!node.concurrent) {
-          context.report({ node, messageId: "preferConcurrently" });
+      IndexStmt(node: Ast.IndexStmtPG) {
+        // `concurrent` lives behind the parser's index signature.
+        if (!node["concurrent"]) {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "preferConcurrently",
+          });
         }
       },
     };

--- a/src/rules/prefer-identity-over-serial.ts
+++ b/src/rules/prefer-identity-over-serial.ts
@@ -1,18 +1,6 @@
 import type { Rule } from "eslint";
-
-const getTypeName = (typeName: any): string | undefined => {
-  if (!typeName || typeof typeName !== "object") return undefined;
-  // typeName carries the qualified name across numeric-string keys "0", "1", ...
-  // The unqualified type name is at the highest-numbered segment; lower
-  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
-  // segment-1 name when present so `public.varchar` still resolves to
-  // `varchar` and not the schema.
-  const v1 = typeName["1"]?.sval;
-  if (typeof v1 === "string") return v1;
-  const v0 = typeName["0"]?.sval;
-  if (typeof v0 === "string") return v0;
-  return undefined;
-};
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
 
 const SERIAL_TYPES = new Set(["smallserial", "serial", "bigserial"]);
 
@@ -34,11 +22,11 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      ColumnDef(node: any) {
-        const t = getTypeName(node?.typeName);
+      ColumnDef(node: Ast.ColumnDef) {
+        const t = getTypeName(node.typeName);
         if (t && SERIAL_TYPES.has(t)) {
           context.report({
-            node,
+            node: node as unknown as Rule.Node,
             messageId: "preferIdentity",
             data: { type: t },
           });

--- a/src/rules/prefer-jsonb-over-json.ts
+++ b/src/rules/prefer-jsonb-over-json.ts
@@ -1,18 +1,6 @@
 import type { Rule } from "eslint";
-
-const getTypeName = (typeName: any): string | undefined => {
-  if (!typeName || typeof typeName !== "object") return undefined;
-  // typeName carries the qualified name across numeric-string keys "0", "1", ...
-  // The unqualified type name is at the highest-numbered segment; lower
-  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
-  // segment-1 name when present so `public.varchar` still resolves to
-  // `varchar` and not the schema.
-  const v1 = typeName["1"]?.sval;
-  if (typeof v1 === "string") return v1;
-  const v0 = typeName["0"]?.sval;
-  if (typeof v0 === "string") return v0;
-  return undefined;
-};
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -30,13 +18,16 @@ const rule: Rule.RuleModule = {
     },
   },
   create(context) {
-    const check = (node: any) => {
-      const t = getTypeName(node?.typeName);
-      if (t === "json") {
-        context.report({ node, messageId: "preferJsonb" });
-      }
+    return {
+      ColumnDef(node: Ast.ColumnDef) {
+        if (getTypeName(node.typeName) === "json") {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "preferJsonb",
+          });
+        }
+      },
     };
-    return { ColumnDef: check };
   },
 };
 

--- a/src/rules/prefer-text-over-varchar.ts
+++ b/src/rules/prefer-text-over-varchar.ts
@@ -1,18 +1,6 @@
 import type { Rule } from "eslint";
-
-const getTypeName = (typeName: any): string | undefined => {
-  if (!typeName || typeof typeName !== "object") return undefined;
-  // typeName carries the qualified name across numeric-string keys "0", "1", ...
-  // The unqualified type name is at the highest-numbered segment; lower
-  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
-  // segment-1 name when present so `public.varchar` still resolves to
-  // `varchar` and not the schema.
-  const v1 = typeName["1"]?.sval;
-  if (typeof v1 === "string") return v1;
-  const v0 = typeName["0"]?.sval;
-  if (typeof v0 === "string") return v0;
-  return undefined;
-};
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -32,10 +20,20 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      ColumnDef(node: any) {
-        const t = getTypeName(node?.typeName);
-        if (t === "varchar" && Array.isArray(node.typeName?.typmods)) {
-          context.report({ node, messageId: "preferText" });
+      ColumnDef(node: Ast.ColumnDef) {
+        const typeName = node.typeName;
+        const name = getTypeName(typeName);
+        // `typmods` lives behind the parser's index signature on the
+        // `names` variant of typeName; reach it via bracket notation.
+        const typmods =
+          typeName != null && typeof typeName === "object"
+            ? (typeName as Record<string, unknown>)["typmods"]
+            : undefined;
+        if (name === "varchar" && Array.isArray(typmods)) {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "preferText",
+          });
         }
       },
     };

--- a/src/rules/prefer-timestamptz.ts
+++ b/src/rules/prefer-timestamptz.ts
@@ -1,18 +1,6 @@
 import type { Rule } from "eslint";
-
-const getTypeName = (typeName: any): string | undefined => {
-  if (!typeName || typeof typeName !== "object") return undefined;
-  // typeName carries the qualified name across numeric-string keys "0", "1", ...
-  // The unqualified type name is at the highest-numbered segment; lower
-  // segments are schema qualifiers (`pg_catalog`, `public`, ...). Prefer the
-  // segment-1 name when present so `public.varchar` still resolves to
-  // `varchar` and not the schema.
-  const v1 = typeName["1"]?.sval;
-  if (typeof v1 === "string") return v1;
-  const v0 = typeName["0"]?.sval;
-  if (typeof v0 === "string") return v0;
-  return undefined;
-};
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -32,10 +20,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      ColumnDef(node: any) {
-        const t = getTypeName(node?.typeName);
-        if (t === "timestamp") {
-          context.report({ node, messageId: "preferTimestamptz" });
+      ColumnDef(node: Ast.ColumnDef) {
+        if (getTypeName(node.typeName) === "timestamp") {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "preferTimestamptz",
+          });
         }
       },
     };

--- a/src/rules/require-limit.ts
+++ b/src/rules/require-limit.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -17,15 +18,15 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      SelectStmt(node: any) {
-        // Check if this is a SELECT statement without LIMIT
-        // A SELECT statement has LIMIT if limitCount exists and limitOption is not LIMIT_OPTION_DEFAULT
+      SelectStmt(node: Ast.SelectStmt) {
+        // A SELECT has a LIMIT if `limitCount` is set and `limitOption`
+        // isn't the parser's default sentinel.
         const hasLimit =
-          node.limitCount && node.limitOption !== "LIMIT_OPTION_DEFAULT";
-
+          node.limitCount != null &&
+          node.limitOption !== "LIMIT_OPTION_DEFAULT";
         if (!hasLimit) {
           context.report({
-            node,
+            node: node as unknown as Rule.Node,
             messageId: "missingLimit",
           });
         }

--- a/src/rules/require-primary-key.ts
+++ b/src/rules/require-primary-key.ts
@@ -1,19 +1,29 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { isColumnDef, isConstraint } from "../utils/ast.js";
 
-const hasPrimaryKey = (tableElts: any[]): boolean => {
+const hasPrimaryKey = (
+  tableElts: ReadonlyArray<Ast.TableElement | unknown>,
+): boolean => {
   for (const elt of tableElts) {
-    if (!elt || typeof elt !== "object") continue;
-    // Table-level constraint: { type: "Constraint", contype: "CONSTR_PRIMARY" }
-    if (elt.type === "Constraint" && elt.contype === "CONSTR_PRIMARY") {
-      return true;
-    }
-    // Column-level: { type: "ColumnDef", constraints: [{ contype: "CONSTR_PRIMARY" }] }
     if (
-      elt.type === "ColumnDef" &&
-      Array.isArray(elt.constraints) &&
-      elt.constraints.some((c: any) => c?.contype === "CONSTR_PRIMARY")
+      isConstraint(elt) &&
+      (elt as Ast.Constraint).contype === "CONSTR_PRIMARY"
     ) {
       return true;
+    }
+    if (isColumnDef(elt)) {
+      const constraints = (elt as Ast.ColumnDef).constraints;
+      if (
+        Array.isArray(constraints) &&
+        constraints.some(
+          (c) =>
+            isConstraint(c) &&
+            (c as Ast.Constraint).contype === "CONSTR_PRIMARY",
+        )
+      ) {
+        return true;
+      }
     }
   }
   return false;
@@ -36,14 +46,20 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      CreateStmt(node: any) {
-        const elts = Array.isArray(node?.tableElts) ? node.tableElts : [];
-        if (elts.length === 0) return; // no columns, e.g. CREATE TABLE ... PARTITION OF
+      CreateStmt(node: Ast.CreateStmt) {
+        const elts = node.tableElts;
+        // No tableElts means CREATE TABLE ... PARTITION OF or similar; skip.
+        if (!Array.isArray(elts) || elts.length === 0) return;
         if (!hasPrimaryKey(elts)) {
+          const relation = node.relation as { relname?: unknown } | undefined;
+          const relname =
+            typeof relation?.relname === "string"
+              ? relation.relname
+              : "<unknown>";
           context.report({
-            node,
+            node: node as unknown as Rule.Node,
             messageId: "missingPrimaryKey",
-            data: { table: node?.relation?.relname ?? "<unknown>" },
+            data: { table: relname },
           });
         }
       },

--- a/src/rules/require-where-in-delete.ts
+++ b/src/rules/require-where-in-delete.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -17,9 +18,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      DeleteStmt(node: any) {
+      DeleteStmt(node: Ast.DeleteStmt) {
         if (!node.whereClause) {
-          context.report({ node, messageId: "missingWhere" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "missingWhere",
+          });
         }
       },
     };

--- a/src/rules/require-where-in-update.ts
+++ b/src/rules/require-where-in-update.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -17,9 +18,12 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      UpdateStmt(node: any) {
+      UpdateStmt(node: Ast.UpdateStmt) {
         if (!node.whereClause) {
-          context.report({ node, messageId: "missingWhere" });
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "missingWhere",
+          });
         }
       },
     };

--- a/src/rules/snake-case-column-name.ts
+++ b/src/rules/snake-case-column-name.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const SNAKE_CASE = /^[a-z][a-z0-9_]*$/;
 
@@ -19,11 +20,11 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     return {
-      ColumnDef(node: any) {
-        const name = node?.colname;
+      ColumnDef(node: Ast.ColumnDef) {
+        const name = node.colname;
         if (typeof name === "string" && !SNAKE_CASE.test(name)) {
           context.report({
-            node,
+            node: node as unknown as Rule.Node,
             messageId: "notSnakeCase",
             data: { name },
           });

--- a/src/rules/snake-case-table-name.ts
+++ b/src/rules/snake-case-table-name.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
 
 const SNAKE_CASE = /^[a-z][a-z0-9_]*$/;
 
@@ -18,19 +19,17 @@ const rule: Rule.RuleModule = {
     },
   },
   create(context) {
-    const checkRelation = (relation: any, node: any) => {
-      const name = relation?.relname;
-      if (typeof name === "string" && !SNAKE_CASE.test(name)) {
-        context.report({
-          node,
-          messageId: "notSnakeCase",
-          data: { name },
-        });
-      }
-    };
     return {
-      CreateStmt(node: any) {
-        checkRelation(node?.relation, node);
+      CreateStmt(node: Ast.CreateStmt) {
+        const relation = node.relation as { relname?: unknown } | undefined;
+        const name = relation?.relname;
+        if (typeof name === "string" && !SNAKE_CASE.test(name)) {
+          context.report({
+            node: node as unknown as Rule.Node,
+            messageId: "notSnakeCase",
+            data: { name },
+          });
+        }
       },
     };
   },

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -1,0 +1,60 @@
+import type { Ast } from "postgresql-eslint-parser";
+
+/**
+ * Local extensions for AST nodes whose interface upstream is incomplete
+ * (the parser exposes only `{ type }` for these but the actual node
+ * carries more fields). Each entry should be removed once the upstream
+ * parser package adds the field to its type definition.
+ */
+export type TruncateStmt = Ast.TruncateStmt & {
+  behavior?: string;
+  relations?: unknown[];
+  restart_seqs?: boolean;
+};
+
+/**
+ * Type predicates for the parser's AST union types. Using them in `if`
+ * conditions narrows the type so callers don't need `as` casts at every
+ * field access.
+ */
+export const isColumnRef = (node: unknown): node is Ast.ColumnRef =>
+  isObjectWithType(node, "ColumnRef");
+
+export const isAStar = (node: unknown): node is Ast.A_Star =>
+  isObjectWithType(node, "A_Star");
+
+export const isResTarget = (node: unknown): node is Ast.ResTarget =>
+  isObjectWithType(node, "ResTarget");
+
+export const isColumnDef = (node: unknown): node is Ast.ColumnDef =>
+  isObjectWithType(node, "ColumnDef");
+
+export const isConstraint = (node: unknown): node is Ast.Constraint =>
+  isObjectWithType(node, "Constraint");
+
+export const isSubLink = (node: unknown): node is Ast.SubLink =>
+  isObjectWithType(node, "SubLink");
+
+const isObjectWithType = <T extends string>(
+  node: unknown,
+  type: T,
+): node is { type: T } => {
+  if (typeof node !== "object" || node === null) return false;
+  return (node as { type?: unknown }).type === type;
+};
+
+/**
+ * Extract the unqualified PostgreSQL type name from a `ColumnDef.typeName`
+ * value. The parser stores qualified names across numeric-string keys
+ * ("0", "1", ...). The type name is at the highest-numbered segment;
+ * lower segments are schema qualifiers (`pg_catalog`, `public`, ...).
+ */
+export const getTypeName = (typeName: unknown): string | undefined => {
+  if (typeof typeName !== "object" || typeName === null) return undefined;
+  const t = typeName as Record<string, unknown>;
+  const v1 = (t["1"] as { sval?: unknown } | undefined)?.sval;
+  if (typeof v1 === "string") return v1;
+  const v0 = (t["0"] as { sval?: unknown } | undefined)?.sval;
+  if (typeof v0 === "string") return v0;
+  return undefined;
+};


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Replace \`node: any\` in every rule's visitor with the parser's typed AST (\`Ast.SelectStmt\`, \`Ast.ColumnDef\`, etc.). Centralise the shared \`getTypeName\` helper and a small set of type predicates in \`src/utils/ast.ts\`.

## Motivation

Reviewers raised \`node: any\` on multiple rule PRs (#63 etc.). It was deferred at the time because doing it once per rule PR would have created 20-way merge conflicts. Now that all rule PRs are merged, this PR does the migration in one cut.

## Changes

- New \`src/utils/ast.ts\` exporting:
  - \`getTypeName\` (the helper that 6 type-checking rules each carried their own copy of)
  - Type predicates \`isColumnRef\`, \`isAStar\`, \`isResTarget\`, \`isColumnDef\`, \`isConstraint\`, \`isSubLink\`
  - A local \`TruncateStmt\` extension for the parser's incomplete \`TruncateStmt\` interface (upstream exposes only \`{ type }\`).
- 22 rule files: visitor parameters now typed with \`Ast.<Stmt>\` (or the local extension).
- The 6 type-checking rules import the shared \`getTypeName\` instead of re-defining it.
- One \`as unknown as Rule.Node\` cast at \`context.report\` per rule, because ESLint's report API expects estree nodes.

## Testing

\`pnpm check:all\` and \`pnpm test\` pass locally (26 tests across 23 files).

## Breaking changes

None — internal refactor. The plugin's exports and behavior are unchanged.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (existing tests cover the runtime behavior; type changes are checked by \`tsc\`).
- [x] I have added or updated documentation where user-visible behavior changed (n/a — internal).
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->