### PR TITLE
feat: add postgresql/no-order-by-ordinal rule

### DIFF
--- a/.changeset/no-order-by-ordinal.md
+++ b/.changeset/no-order-by-ordinal.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-order-by-ordinal` rule: warns on positional `ORDER BY` references like `ORDER BY 1, 2`, which silently break when the SELECT list changes. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -570,6 +570,30 @@ SELECT * FROM users LIMIT 100;
 SELECT name, email FROM users WHERE active = true LIMIT 50;
 ```
 
+### `postgresql/no-order-by-ordinal`
+
+Disallows positional `ORDER BY` references such as `ORDER BY 1, 2`. Ordinals silently change meaning when the SELECT list is reordered or a column is inserted, and they're invisible at the call site of any view or CTE that contains them. Reference the column by name or by an alias instead.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT id, name FROM users ORDER BY 1;
+SELECT id, name, email FROM users ORDER BY 1, 2 DESC;
+```
+
+✅ Correct:
+
+```sql
+SELECT id, name FROM users ORDER BY name;
+SELECT id, name AS display_name FROM users ORDER BY display_name;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -340,6 +340,25 @@ export const rules: RuleMeta[] = [
       "SELECT name, email FROM users WHERE active = true LIMIT 50;",
     ],
   },
+  {
+    name: "no-order-by-ordinal",
+    description:
+      "Disallow positional `ORDER BY` references (e.g., `ORDER BY 1`).",
+    longDescription:
+      "`ORDER BY 1, 2` silently changes meaning when the SELECT list is reordered or a column is inserted. Worse, the intent is invisible at any callsite that consumes the query via a view or CTE. Reference columns by name or by an alias.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "style",
+    incorrect: [
+      "SELECT id, name FROM users ORDER BY 1;",
+      "SELECT id, name, email FROM users ORDER BY 1, 2 DESC;",
+    ],
+    correct: [
+      "SELECT id, name FROM users ORDER BY name;",
+      "SELECT id, name AS display_name FROM users ORDER BY display_name;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import noImplicitJoin from "./rules/no-implicit-join.js";
 import noMoneyType from "./rules/no-money-type.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noNotInSubquery from "./rules/no-not-in-subquery.js";
+import noOrderByOrdinal from "./rules/no-order-by-ordinal.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
@@ -33,6 +34,7 @@ const rules = {
   "no-money-type": noMoneyType,
   "no-natural-join": noNaturalJoin,
   "no-not-in-subquery": noNotInSubquery,
+  "no-order-by-ordinal": noOrderByOrdinal,
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
   "no-truncate-cascade": noTruncateCascade,
@@ -78,6 +80,7 @@ plugin.configs = {
       "postgresql/no-money-type": "error",
       "postgresql/no-natural-join": "error",
       "postgresql/no-not-in-subquery": "error",
+      "postgresql/no-order-by-ordinal": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/prefer-identity-over-serial": "warn",

--- a/src/rules/no-order-by-ordinal.ts
+++ b/src/rules/no-order-by-ordinal.ts
@@ -1,0 +1,45 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const isIntegerConst = (node: unknown): boolean => {
+  if (typeof node !== "object" || node === null) return false;
+  const n = node as { type?: unknown; ival?: unknown };
+  return n.type === "A_Const" && typeof n.ival === "object" && n.ival !== null;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `ORDER BY <position>` (positional/ordinal references); use the column name or alias instead",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noOrderByOrdinal:
+        "`ORDER BY <position>` silently breaks when the SELECT list changes. Use the column name or alias instead.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        const sortClause = node.sortClause;
+        if (!Array.isArray(sortClause)) return;
+        for (const sortBy of sortClause) {
+          if (!sortBy || sortBy.type !== "SortBy") continue;
+          if (isIntegerConst(sortBy.node)) {
+            context.report({
+              node: sortBy as unknown as Rule.Node,
+              messageId: "noOrderByOrdinal",
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-order-by-ordinal/invalid/order-by-multiple-positions-errors.expected.json
+++ b/tests/fixtures/no-order-by-ordinal/invalid/order-by-multiple-positions-errors.expected.json
@@ -1,0 +1,8 @@
+[
+  {
+    "messageId": "noOrderByOrdinal"
+  },
+  {
+    "messageId": "noOrderByOrdinal"
+  }
+]

--- a/tests/fixtures/no-order-by-ordinal/invalid/order-by-multiple-positions.sql
+++ b/tests/fixtures/no-order-by-ordinal/invalid/order-by-multiple-positions.sql
@@ -1,0 +1,1 @@
+SELECT id, name, email FROM users ORDER BY 1, 2 DESC;

--- a/tests/fixtures/no-order-by-ordinal/invalid/order-by-position-errors.expected.json
+++ b/tests/fixtures/no-order-by-ordinal/invalid/order-by-position-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noOrderByOrdinal"
+  }
+]

--- a/tests/fixtures/no-order-by-ordinal/invalid/order-by-position.sql
+++ b/tests/fixtures/no-order-by-ordinal/invalid/order-by-position.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users ORDER BY 1;

--- a/tests/fixtures/no-order-by-ordinal/valid/no-order-by.sql
+++ b/tests/fixtures/no-order-by-ordinal/valid/no-order-by.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users;

--- a/tests/fixtures/no-order-by-ordinal/valid/order-by-name.sql
+++ b/tests/fixtures/no-order-by-ordinal/valid/order-by-name.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users ORDER BY name;

--- a/tests/no-order-by-ordinal.test.ts
+++ b/tests/no-order-by-ordinal.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-order-by-ordinal.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-order-by-ordinal",
+  rule,
+  "should disallow positional ORDER BY references",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-order-by-ordinal`, a new rule that disallows positional `ORDER BY` references such as `ORDER BY 1, 2`. Ordinal references silently change meaning when the SELECT list is reordered or a column is inserted, and the intent is invisible at any callsite that consumes the query through a view or CTE. Reference columns by name or alias instead.

## Motivation

Positional `ORDER BY` is a long-standing readability and fragility footgun: refactor the SELECT list and ordering silently swaps to a different column. SQL style guides (Joe Celko's, Mode Analytics, GitLab) all recommend against it.

## Changes

- New rule `postgresql/no-order-by-ordinal`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-order-by-ordinal.test.ts` runs the fixture-driven tests.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->