### PR TITLE
feat: add postgresql/no-group-by-ordinal rule

### DIFF
--- a/.changeset/no-group-by-ordinal.md
+++ b/.changeset/no-group-by-ordinal.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-group-by-ordinal` rule: warns on positional `GROUP BY` references like `GROUP BY 1, 2`, which silently shift to a different column when the SELECT list is reordered. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -594,6 +594,30 @@ SELECT id, name FROM users ORDER BY name;
 SELECT id, name AS display_name FROM users ORDER BY display_name;
 ```
 
+### `postgresql/no-group-by-ordinal`
+
+Disallows positional `GROUP BY` references such as `GROUP BY 1, 2`. Same fragility as positional `ORDER BY`: reorder the SELECT list and the grouping silently shifts to a different column, often producing plausible-looking but wrong aggregates.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT category, count(*) FROM items GROUP BY 1;
+SELECT region, category, sum(amount) FROM sales GROUP BY 1, 2;
+```
+
+✅ Correct:
+
+```sql
+SELECT category, count(*) FROM items GROUP BY category;
+SELECT region, category, sum(amount) FROM sales GROUP BY region, category;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -359,6 +359,25 @@ export const rules: RuleMeta[] = [
       "SELECT id, name AS display_name FROM users ORDER BY display_name;",
     ],
   },
+  {
+    name: "no-group-by-ordinal",
+    description:
+      "Disallow positional `GROUP BY` references (e.g., `GROUP BY 1`).",
+    longDescription:
+      "Same fragility as positional `ORDER BY`: reordering the SELECT list silently shifts the grouping to a different column, producing plausible-looking but wrong aggregates. Reference the column by name or by the grouping expression.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "style",
+    incorrect: [
+      "SELECT category, count(*) FROM items GROUP BY 1;",
+      "SELECT region, category, sum(amount) FROM sales GROUP BY 1, 2;",
+    ],
+    correct: [
+      "SELECT category, count(*) FROM items GROUP BY category;",
+      "SELECT region, category, sum(amount) FROM sales GROUP BY region, category;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import noCharType from "./rules/no-char-type.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
+import noGroupByOrdinal from "./rules/no-group-by-ordinal.js";
 import noImplicitJoin from "./rules/no-implicit-join.js";
 import noMoneyType from "./rules/no-money-type.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
@@ -30,6 +31,7 @@ const rules = {
   "no-cross-join": noCrossJoin,
   "no-drop-table-cascade": noDropTableCascade,
   "no-grant-to-public": noGrantToPublic,
+  "no-group-by-ordinal": noGroupByOrdinal,
   "no-implicit-join": noImplicitJoin,
   "no-money-type": noMoneyType,
   "no-natural-join": noNaturalJoin,
@@ -76,6 +78,7 @@ plugin.configs = {
       "postgresql/no-cross-join": "warn",
       "postgresql/no-drop-table-cascade": "warn",
       "postgresql/no-grant-to-public": "warn",
+      "postgresql/no-group-by-ordinal": "warn",
       "postgresql/no-implicit-join": "warn",
       "postgresql/no-money-type": "error",
       "postgresql/no-natural-join": "error",

--- a/src/rules/no-group-by-ordinal.ts
+++ b/src/rules/no-group-by-ordinal.ts
@@ -1,0 +1,44 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const isIntegerConst = (node: unknown): boolean => {
+  if (typeof node !== "object" || node === null) return false;
+  const n = node as { type?: unknown; ival?: unknown };
+  return n.type === "A_Const" && typeof n.ival === "object" && n.ival !== null;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `GROUP BY <position>` (positional/ordinal references); use the column name or expression instead",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noGroupByOrdinal:
+        "`GROUP BY <position>` silently breaks when the SELECT list changes. Use the column name or the expression itself.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        const groupClause = node.groupClause;
+        if (!Array.isArray(groupClause)) return;
+        for (const expr of groupClause) {
+          if (isIntegerConst(expr)) {
+            context.report({
+              node: expr as unknown as Rule.Node,
+              messageId: "noGroupByOrdinal",
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-group-by-ordinal/invalid/group-by-multiple-positions-errors.expected.json
+++ b/tests/fixtures/no-group-by-ordinal/invalid/group-by-multiple-positions-errors.expected.json
@@ -1,0 +1,8 @@
+[
+  {
+    "messageId": "noGroupByOrdinal"
+  },
+  {
+    "messageId": "noGroupByOrdinal"
+  }
+]

--- a/tests/fixtures/no-group-by-ordinal/invalid/group-by-multiple-positions.sql
+++ b/tests/fixtures/no-group-by-ordinal/invalid/group-by-multiple-positions.sql
@@ -1,0 +1,1 @@
+SELECT region, category, sum(amount) FROM sales GROUP BY 1, 2;

--- a/tests/fixtures/no-group-by-ordinal/invalid/group-by-position-errors.expected.json
+++ b/tests/fixtures/no-group-by-ordinal/invalid/group-by-position-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noGroupByOrdinal"
+  }
+]

--- a/tests/fixtures/no-group-by-ordinal/invalid/group-by-position.sql
+++ b/tests/fixtures/no-group-by-ordinal/invalid/group-by-position.sql
@@ -1,0 +1,1 @@
+SELECT category, count(*) FROM items GROUP BY 1;

--- a/tests/fixtures/no-group-by-ordinal/valid/group-by-name.sql
+++ b/tests/fixtures/no-group-by-ordinal/valid/group-by-name.sql
@@ -1,0 +1,1 @@
+SELECT category, count(*) FROM items GROUP BY category;

--- a/tests/fixtures/no-group-by-ordinal/valid/no-group-by.sql
+++ b/tests/fixtures/no-group-by-ordinal/valid/no-group-by.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users;

--- a/tests/no-group-by-ordinal.test.ts
+++ b/tests/no-group-by-ordinal.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-group-by-ordinal.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-group-by-ordinal",
+  rule,
+  "should disallow positional GROUP BY references",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-group-by-ordinal`, a new rule that disallows positional `GROUP BY` references such as `GROUP BY 1, 2`. Same fragility as positional `ORDER BY`: reordering the SELECT list silently shifts the grouping to a different column, producing plausible-looking but wrong aggregates.

## Motivation

Companion to the `no-order-by-ordinal` rule landed in the previous PR. Same readability/safety concern: positional grouping is fragile against SELECT-list edits and invisible at the consuming view/CTE level.

## Changes

- New rule `postgresql/no-group-by-ordinal`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-group-by-ordinal.test.ts` runs the fixture-driven tests.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->