### PR TITLE
feat: add postgresql/no-distinct-on-without-order-by rule

### DIFF
--- a/.changeset/no-distinct-on-without-order-by.md
+++ b/.changeset/no-distinct-on-without-order-by.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-distinct-on-without-order-by` rule: errors when `SELECT DISTINCT ON (...)` is used without `ORDER BY`. Without an ordering, the surviving row in each group is arbitrary and depends on scan order. Enabled at `error` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -618,6 +618,30 @@ SELECT category, count(*) FROM items GROUP BY category;
 SELECT region, category, sum(amount) FROM sales GROUP BY region, category;
 ```
 
+### `postgresql/no-distinct-on-without-order-by`
+
+Errors on `SELECT DISTINCT ON (...)` queries that do not also specify `ORDER BY`. Without an explicit ordering PostgreSQL keeps an arbitrary row from each group, so the result depends on scan order and changes silently across plan or stats updates. Pair `DISTINCT ON` with an `ORDER BY` whose leading columns match the `DISTINCT ON` expressions so the surviving row is deterministic.
+
+**Type**: Problem  
+**Recommended**: ✅ Error  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT DISTINCT ON (customer_id) customer_id, amount FROM orders;
+```
+
+✅ Correct:
+
+```sql
+SELECT DISTINCT ON (customer_id) customer_id, amount
+FROM orders
+ORDER BY customer_id, created_at DESC;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -378,6 +378,24 @@ export const rules: RuleMeta[] = [
       "SELECT region, category, sum(amount) FROM sales GROUP BY region, category;",
     ],
   },
+  {
+    name: "no-distinct-on-without-order-by",
+    description:
+      "Require ORDER BY alongside `SELECT DISTINCT ON (...)` so the surviving row is deterministic.",
+    longDescription:
+      "Without `ORDER BY`, PostgreSQL keeps an arbitrary row from each group of `DISTINCT ON` — the result depends on scan order and changes silently across plan or stats updates. Pair `DISTINCT ON` with an `ORDER BY` whose leading columns match.",
+    type: "problem",
+    recommended: "error",
+    fixable: false,
+    category: "safety",
+    incorrect: [
+      "SELECT DISTINCT ON (customer_id) customer_id, amount FROM orders;",
+    ],
+    correct: [
+      "SELECT DISTINCT ON (customer_id) customer_id, amount\nFROM orders\nORDER BY customer_id, created_at DESC;",
+      "SELECT DISTINCT customer_id FROM orders;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import postgresqlParser from "postgresql-eslint-parser";
 import { name, version } from "./meta.js";
 import noCharType from "./rules/no-char-type.js";
 import noCrossJoin from "./rules/no-cross-join.js";
+import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noGroupByOrdinal from "./rules/no-group-by-ordinal.js";
@@ -29,6 +30,7 @@ import snakeCaseTableName from "./rules/snake-case-table-name.js";
 const rules = {
   "no-char-type": noCharType,
   "no-cross-join": noCrossJoin,
+  "no-distinct-on-without-order-by": noDistinctOnWithoutOrderBy,
   "no-drop-table-cascade": noDropTableCascade,
   "no-grant-to-public": noGrantToPublic,
   "no-group-by-ordinal": noGroupByOrdinal,
@@ -76,6 +78,7 @@ plugin.configs = {
     rules: {
       "postgresql/no-char-type": "warn",
       "postgresql/no-cross-join": "warn",
+      "postgresql/no-distinct-on-without-order-by": "error",
       "postgresql/no-drop-table-cascade": "warn",
       "postgresql/no-grant-to-public": "warn",
       "postgresql/no-group-by-ordinal": "warn",

--- a/src/rules/no-distinct-on-without-order-by.ts
+++ b/src/rules/no-distinct-on-without-order-by.ts
@@ -1,0 +1,46 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const hasDistinctOn = (
+  distinctClause: Ast.SelectStmt["distinctClause"],
+): boolean => {
+  if (!Array.isArray(distinctClause)) return false;
+  // Plain `DISTINCT` parses as a single element with no `type` field; only
+  // `DISTINCT ON (...)` populates the elements with real expressions.
+  return distinctClause.some(
+    (e) => typeof e === "object" && e !== null && "type" in e,
+  );
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `SELECT DISTINCT ON (...)` without an `ORDER BY`; the surviving row in each group is otherwise non-deterministic",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDistinctOnWithoutOrderBy:
+        "`DISTINCT ON (...)` keeps an arbitrary row from each group unless `ORDER BY` is specified. Add an `ORDER BY` whose leading columns match the `DISTINCT ON` expressions.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        if (!hasDistinctOn(node.distinctClause)) return;
+        if (Array.isArray(node.sortClause) && node.sortClause.length > 0)
+          return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noDistinctOnWithoutOrderBy",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-distinct-on-without-order-by/invalid/distinct-on-no-order-errors.expected.json
+++ b/tests/fixtures/no-distinct-on-without-order-by/invalid/distinct-on-no-order-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noDistinctOnWithoutOrderBy"
+  }
+]

--- a/tests/fixtures/no-distinct-on-without-order-by/invalid/distinct-on-no-order.sql
+++ b/tests/fixtures/no-distinct-on-without-order-by/invalid/distinct-on-no-order.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT ON (customer_id) customer_id, amount FROM orders;

--- a/tests/fixtures/no-distinct-on-without-order-by/valid/distinct-on-with-order.sql
+++ b/tests/fixtures/no-distinct-on-without-order-by/valid/distinct-on-with-order.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT ON (customer_id) customer_id, amount
+FROM orders
+ORDER BY customer_id, created_at DESC;

--- a/tests/fixtures/no-distinct-on-without-order-by/valid/plain-distinct.sql
+++ b/tests/fixtures/no-distinct-on-without-order-by/valid/plain-distinct.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT customer_id FROM orders;

--- a/tests/no-distinct-on-without-order-by.test.ts
+++ b/tests/no-distinct-on-without-order-by.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-distinct-on-without-order-by.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-distinct-on-without-order-by",
+  rule,
+  "should require ORDER BY alongside DISTINCT ON",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-distinct-on-without-order-by`, a new rule that errors when `SELECT DISTINCT ON (...)` is used without `ORDER BY`. Without an explicit ordering, the surviving row in each group is arbitrary and depends on scan order — exactly the kind of non-determinism that changes silently across plan or stats updates.

## Motivation

`DISTINCT ON` is one of the most commonly misused PostgreSQL features. The PG docs explicitly warn: "the DISTINCT ON expressions are interpreted using the same rules as for ORDER BY ... unless ORDER BY is used to ensure that the desired row appears first."

## Changes

- New rule `postgresql/no-distinct-on-without-order-by`, enabled at `error` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-distinct-on-without-order-by.test.ts` runs the fixture-driven tests, including a valid case for plain `DISTINCT` to confirm the rule does not over-fire.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `error`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->