### PR TITLE
feat: add postgresql/no-leading-wildcard-like rule

### DIFF
--- a/.changeset/no-leading-wildcard-like.md
+++ b/.changeset/no-leading-wildcard-like.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-leading-wildcard-like` rule: warns on `LIKE`/`ILIKE` patterns that begin with `%`, which cannot use a B-tree index and force a sequential scan. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -642,6 +642,30 @@ FROM orders
 ORDER BY customer_id, created_at DESC;
 ```
 
+### `postgresql/no-leading-wildcard-like`
+
+Warns on `LIKE` / `ILIKE` patterns that begin with `%`. A pattern like `'%foo'` or `'%foo%'` cannot use a plain B-tree index and forces PostgreSQL into a sequential scan. If substring search is genuinely needed, use a `pg_trgm` GIN index, full-text search (`tsvector`), or rework the schema so the prefix is indexable.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT id FROM users WHERE email LIKE '%@example.com';
+SELECT id FROM users WHERE name ILIKE '%smith%';
+```
+
+✅ Correct:
+
+```sql
+SELECT id FROM users WHERE email LIKE 'admin@%';
+SELECT id FROM users WHERE email = 'admin@example.com';
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -396,6 +396,25 @@ export const rules: RuleMeta[] = [
       "SELECT DISTINCT customer_id FROM orders;",
     ],
   },
+  {
+    name: "no-leading-wildcard-like",
+    description:
+      "Warn on `LIKE`/`ILIKE` patterns that begin with `%`; they force sequential scans.",
+    longDescription:
+      "A pattern like `'%foo'` or `'%foo%'` cannot use a plain B-tree index and forces PostgreSQL into a sequential scan. Use a `pg_trgm` GIN index or full-text search if substring matching is required.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "perf",
+    incorrect: [
+      "SELECT id FROM users WHERE email LIKE '%@example.com';",
+      "SELECT id FROM users WHERE name ILIKE '%smith%';",
+    ],
+    correct: [
+      "SELECT id FROM users WHERE email LIKE 'admin@%';",
+      "SELECT id FROM users WHERE email = 'admin@example.com';",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noGroupByOrdinal from "./rules/no-group-by-ordinal.js";
 import noImplicitJoin from "./rules/no-implicit-join.js";
+import noLeadingWildcardLike from "./rules/no-leading-wildcard-like.js";
 import noMoneyType from "./rules/no-money-type.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noNotInSubquery from "./rules/no-not-in-subquery.js";
@@ -35,6 +36,7 @@ const rules = {
   "no-grant-to-public": noGrantToPublic,
   "no-group-by-ordinal": noGroupByOrdinal,
   "no-implicit-join": noImplicitJoin,
+  "no-leading-wildcard-like": noLeadingWildcardLike,
   "no-money-type": noMoneyType,
   "no-natural-join": noNaturalJoin,
   "no-not-in-subquery": noNotInSubquery,
@@ -83,6 +85,7 @@ plugin.configs = {
       "postgresql/no-grant-to-public": "warn",
       "postgresql/no-group-by-ordinal": "warn",
       "postgresql/no-implicit-join": "warn",
+      "postgresql/no-leading-wildcard-like": "warn",
       "postgresql/no-money-type": "error",
       "postgresql/no-natural-join": "error",
       "postgresql/no-not-in-subquery": "error",

--- a/src/rules/no-leading-wildcard-like.ts
+++ b/src/rules/no-leading-wildcard-like.ts
@@ -1,0 +1,47 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const getStringConst = (node: unknown): string | undefined => {
+  if (typeof node !== "object" || node === null) return undefined;
+  const n = node as { type?: unknown; sval?: { sval?: unknown } };
+  if (n.type !== "A_Const") return undefined;
+  const sval = n.sval?.sval;
+  return typeof sval === "string" ? sval : undefined;
+};
+
+const isLikeKind = (kind: unknown): boolean =>
+  kind === "AEXPR_LIKE" || kind === "AEXPR_ILIKE";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `LIKE`/`ILIKE` patterns that begin with `%` because they cannot use a B-tree index and force a full scan",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noLeadingWildcardLike:
+        "`LIKE`/`ILIKE` patterns that begin with `%` cannot use a B-tree index and force a sequential scan. If you need substring search, use a `pg_trgm` GIN index, full-text search, or rework the schema so the prefix is indexable.",
+    },
+  },
+  create(context) {
+    return {
+      A_Expr(node: Ast.A_Expr) {
+        if (!isLikeKind(node.kind)) return;
+        const pattern = getStringConst(node.rexpr);
+        if (typeof pattern !== "string") return;
+        if (!pattern.startsWith("%")) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noLeadingWildcardLike",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard-errors.expected.json
+++ b/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noLeadingWildcardLike"
+  }
+]

--- a/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard-ilike-errors.expected.json
+++ b/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard-ilike-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noLeadingWildcardLike"
+  }
+]

--- a/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard-ilike.sql
+++ b/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard-ilike.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users WHERE name ILIKE '%smith%';

--- a/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard.sql
+++ b/tests/fixtures/no-leading-wildcard-like/invalid/leading-wildcard.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users WHERE email LIKE '%@example.com';

--- a/tests/fixtures/no-leading-wildcard-like/valid/anchored-prefix.sql
+++ b/tests/fixtures/no-leading-wildcard-like/valid/anchored-prefix.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users WHERE email LIKE 'admin@%';

--- a/tests/fixtures/no-leading-wildcard-like/valid/equals.sql
+++ b/tests/fixtures/no-leading-wildcard-like/valid/equals.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users WHERE email = 'admin@example.com';

--- a/tests/no-leading-wildcard-like.test.ts
+++ b/tests/no-leading-wildcard-like.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-leading-wildcard-like.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-leading-wildcard-like",
+  rule,
+  "should disallow LIKE/ILIKE patterns that start with %",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-leading-wildcard-like`, a new rule that warns on `LIKE`/`ILIKE` patterns starting with `%`. Such patterns cannot use a B-tree index and force a sequential scan, which is a well-known performance footgun for substring search.

## Motivation

LIKE with a leading wildcard is one of the top performance issues that surfaces in slow-query logs. The plugin already lints query correctness; sargability deserves the same first-class treatment.

## Changes

- New rule `postgresql/no-leading-wildcard-like`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-leading-wildcard-like.test.ts` runs fixture-driven tests covering both `LIKE` and `ILIKE`, with negative cases for anchored prefixes and plain `=`.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->