### PR TITLE
feat: add postgresql/no-select-into rule

### DIFF
--- a/.changeset/no-select-into.md
+++ b/.changeset/no-select-into.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-select-into` rule: warns on `SELECT ... INTO target FROM ...`, which silently creates a new table and is confusable with PL/pgSQL's row-assignment form. Prefer `CREATE TABLE target AS SELECT ...`. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -690,6 +690,28 @@ ALTER TABLE users ADD COLUMN status text;
 ALTER TABLE users ADD COLUMN id bigint GENERATED ALWAYS AS IDENTITY NOT NULL;
 ```
 
+### `postgresql/no-select-into`
+
+Warns on `SELECT ... INTO target FROM ...`, which silently creates a new table named `target`. The syntax is confusable with PL/pgSQL's `SELECT INTO variable` (a row assignment, not a table creation) and is omitted from many SQL primers. Use `CREATE TABLE target AS SELECT ...` so the intent reads back.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT id, name INTO archived_users FROM users WHERE inactive;
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -431,6 +431,23 @@ export const rules: RuleMeta[] = [
       "ALTER TABLE users ADD COLUMN status text;",
     ],
   },
+  {
+    name: "no-select-into",
+    description:
+      "Disallow `SELECT ... INTO target FROM ...`; prefer `CREATE TABLE AS SELECT`.",
+    longDescription:
+      "`SELECT ... INTO target` silently creates a new table. The syntax is confusable with PL/pgSQL's `SELECT INTO variable` and is omitted from most SQL primers. `CREATE TABLE target AS SELECT ...` reads back as the intent.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "style",
+    incorrect: [
+      "SELECT id, name INTO archived_users FROM users WHERE inactive;",
+    ],
+    correct: [
+      "CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import noMoneyType from "./rules/no-money-type.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noNotInSubquery from "./rules/no-not-in-subquery.js";
 import noOrderByOrdinal from "./rules/no-order-by-ordinal.js";
+import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
@@ -43,6 +44,7 @@ const rules = {
   "no-natural-join": noNaturalJoin,
   "no-not-in-subquery": noNotInSubquery,
   "no-order-by-ordinal": noOrderByOrdinal,
+  "no-select-into": noSelectInto,
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
   "no-truncate-cascade": noTruncateCascade,
@@ -93,6 +95,7 @@ plugin.configs = {
       "postgresql/no-natural-join": "error",
       "postgresql/no-not-in-subquery": "error",
       "postgresql/no-order-by-ordinal": "warn",
+      "postgresql/no-select-into": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/prefer-identity-over-serial": "warn",

--- a/src/rules/no-select-into.ts
+++ b/src/rules/no-select-into.ts
@@ -1,0 +1,33 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `SELECT ... INTO target FROM ...` (creates a new table); use `CREATE TABLE AS SELECT ...` instead",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noSelectInto:
+        "`SELECT ... INTO target FROM ...` creates a new table whose semantics differ from a regular `SELECT` and conflict with PL/pgSQL's `SELECT INTO variable`. Use `CREATE TABLE target AS SELECT ...` so the intent is explicit.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        if (!node.intoClause) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noSelectInto",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-select-into/invalid/select-into-errors.expected.json
+++ b/tests/fixtures/no-select-into/invalid/select-into-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noSelectInto"
+  }
+]

--- a/tests/fixtures/no-select-into/invalid/select-into.sql
+++ b/tests/fixtures/no-select-into/invalid/select-into.sql
@@ -1,0 +1,1 @@
+SELECT id, name INTO archived_users FROM users WHERE inactive;

--- a/tests/fixtures/no-select-into/valid/create-table-as.sql
+++ b/tests/fixtures/no-select-into/valid/create-table-as.sql
@@ -1,0 +1,1 @@
+CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;

--- a/tests/fixtures/no-select-into/valid/plain-select.sql
+++ b/tests/fixtures/no-select-into/valid/plain-select.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users WHERE inactive;

--- a/tests/no-select-into.test.ts
+++ b/tests/no-select-into.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-select-into.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-select-into", rule, "should disallow SELECT ... INTO target");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-select-into`, a rule that warns on `SELECT ... INTO target FROM ...`. The syntax silently creates a new table, is confusable with PL/pgSQL's `SELECT INTO variable` (row assignment, not table creation), and is omitted from most SQL primers.

## Motivation

`SELECT ... INTO` is a feature even experienced PG developers misuse. The canonical replacement `CREATE TABLE AS SELECT` is in the manual's "preferred way of creating a new table from a query" note. Catching the SELECT INTO form at lint time nudges code toward the readable equivalent.

## Changes

- New rule `postgresql/no-select-into`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-select-into.test.ts` runs fixture-driven tests covering the SELECT INTO form, plus negative cases for plain SELECT and CREATE TABLE AS.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->