### PR TITLE
feat: add postgresql/prefer-coalesce-over-case rule

### DIFF
--- a/.changeset/prefer-coalesce-over-case.md
+++ b/.changeset/prefer-coalesce-over-case.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-coalesce-over-case` rule: flags `CASE WHEN x IS NULL THEN y ELSE x END` (and its `IS NOT NULL` mirror) and recommends the equivalent `COALESCE(x, y)`. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -712,6 +712,35 @@ SELECT id, name INTO archived_users FROM users WHERE inactive;
 CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;
 ```
 
+### `postgresql/prefer-coalesce-over-case`
+
+Flags the verbose `CASE WHEN x IS NULL THEN fallback ELSE x END` (and its `IS NOT NULL` mirror) and recommends `COALESCE(x, fallback)`. `COALESCE` is shorter, evaluates `x` once, and is the form every PostgreSQL planner optimizes directly.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT CASE WHEN nickname IS NULL THEN full_name ELSE nickname END FROM users;
+SELECT CASE WHEN nickname IS NOT NULL THEN nickname ELSE full_name END FROM users;
+```
+
+✅ Correct:
+
+```sql
+SELECT COALESCE(nickname, full_name) FROM users;
+-- Multi-arm CASE that isn't just a null fallback is not flagged.
+SELECT CASE
+  WHEN nickname IS NULL THEN full_name
+  WHEN length(nickname) = 0 THEN full_name
+  ELSE nickname
+END FROM users;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -448,6 +448,22 @@ export const rules: RuleMeta[] = [
       "CREATE TABLE archived_users AS SELECT id, name FROM users WHERE inactive;",
     ],
   },
+  {
+    name: "prefer-coalesce-over-case",
+    description:
+      "Flag `CASE WHEN x IS NULL THEN y ELSE x END` and recommend `COALESCE(x, y)`.",
+    longDescription:
+      "`COALESCE` is shorter, evaluates `x` once, and is the form every PostgreSQL planner optimizes directly. Also catches the mirrored `IS NOT NULL` form. Multi-arm CASEs that go beyond a single null-fallback are not flagged.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "style",
+    incorrect: [
+      "SELECT CASE WHEN nickname IS NULL THEN full_name ELSE nickname END FROM users;",
+      "SELECT CASE WHEN nickname IS NOT NULL THEN nickname ELSE full_name END FROM users;",
+    ],
+    correct: ["SELECT COALESCE(nickname, full_name) FROM users;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
+import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
 import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -48,6 +49,7 @@ const rules = {
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
   "no-truncate-cascade": noTruncateCascade,
+  "prefer-coalesce-over-case": preferCoalesceOverCase,
   "prefer-create-index-concurrently": preferCreateIndexConcurrently,
   "prefer-identity-over-serial": preferIdentityOverSerial,
   "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -98,6 +100,7 @@ plugin.configs = {
       "postgresql/no-select-into": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-truncate-cascade": "warn",
+      "postgresql/prefer-coalesce-over-case": "warn",
       "postgresql/prefer-identity-over-serial": "warn",
       "postgresql/prefer-jsonb-over-json": "warn",
       "postgresql/prefer-text-over-varchar": "warn",

--- a/src/rules/prefer-coalesce-over-case.ts
+++ b/src/rules/prefer-coalesce-over-case.ts
@@ -1,0 +1,110 @@
+import type { Rule } from "eslint";
+
+interface NullTestNode {
+  type: "NullTest";
+  arg: unknown;
+  nulltesttype: "IS_NULL" | "IS_NOT_NULL";
+}
+
+interface CaseWhenNode {
+  type: "CaseWhen";
+  expr: unknown;
+  result: unknown;
+}
+
+interface CaseExprNode {
+  type: "CaseExpr";
+  arg?: unknown;
+  args?: CaseWhenNode[];
+  defresult?: unknown;
+}
+
+const NOISE_KEYS = new Set(["parent", "loc", "range"]);
+
+const sameNode = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => sameNode(v, b[i]));
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao).filter((k) => !NOISE_KEYS.has(k));
+  const bk = Object.keys(bo).filter((k) => !NOISE_KEYS.has(k));
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) => sameNode(ao[k], bo[k]));
+};
+
+const isNullTest = (
+  node: unknown,
+  kind: "IS_NULL" | "IS_NOT_NULL",
+): node is NullTestNode => {
+  if (typeof node !== "object" || node === null) return false;
+  const n = node as { type?: unknown; nulltesttype?: unknown };
+  return n.type === "NullTest" && n.nulltesttype === kind;
+};
+
+const isCoalesceShape = (node: CaseExprNode): boolean => {
+  // Only the searched `CASE WHEN ... END` form (no `CASE expr WHEN ...`)
+  // collapses to COALESCE.
+  if (node.arg !== undefined) return false;
+  const args = node.args;
+  if (!Array.isArray(args) || args.length !== 1) return false;
+  const branch = args[0];
+  if (!branch) return false;
+  const expr = branch.expr;
+  if (node.defresult === undefined) return false;
+
+  // CASE WHEN x IS NULL THEN y ELSE x END  →  COALESCE(x, y)
+  if (
+    isNullTest(expr, "IS_NULL") &&
+    sameNode(expr.arg, node.defresult) &&
+    !sameNode(expr.arg, branch.result)
+  ) {
+    return true;
+  }
+  // CASE WHEN x IS NOT NULL THEN x ELSE y END  →  COALESCE(x, y)
+  if (
+    isNullTest(expr, "IS_NOT_NULL") &&
+    sameNode(expr.arg, branch.result) &&
+    !sameNode(expr.arg, node.defresult)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer `COALESCE(x, y)` over `CASE WHEN x IS NULL THEN y ELSE x END` (and its IS NOT NULL mirror)",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferCoalesceOverCase:
+        "`CASE WHEN ... IS NULL THEN ... ELSE ... END` is a verbose `COALESCE`. Use `COALESCE(x, fallback)` instead.",
+    },
+  },
+  create(context) {
+    return {
+      CaseExpr(node: CaseExprNode) {
+        if (!isCoalesceShape(node)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "preferCoalesceOverCase",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-coalesce-over-case/invalid/is-not-null-errors.expected.json
+++ b/tests/fixtures/prefer-coalesce-over-case/invalid/is-not-null-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferCoalesceOverCase"
+  }
+]

--- a/tests/fixtures/prefer-coalesce-over-case/invalid/is-not-null.sql
+++ b/tests/fixtures/prefer-coalesce-over-case/invalid/is-not-null.sql
@@ -1,0 +1,2 @@
+SELECT CASE WHEN nickname IS NOT NULL THEN nickname ELSE full_name END AS display
+FROM users;

--- a/tests/fixtures/prefer-coalesce-over-case/invalid/is-null-errors.expected.json
+++ b/tests/fixtures/prefer-coalesce-over-case/invalid/is-null-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferCoalesceOverCase"
+  }
+]

--- a/tests/fixtures/prefer-coalesce-over-case/invalid/is-null.sql
+++ b/tests/fixtures/prefer-coalesce-over-case/invalid/is-null.sql
@@ -1,0 +1,2 @@
+SELECT CASE WHEN nickname IS NULL THEN full_name ELSE nickname END AS display
+FROM users;

--- a/tests/fixtures/prefer-coalesce-over-case/valid/coalesce.sql
+++ b/tests/fixtures/prefer-coalesce-over-case/valid/coalesce.sql
@@ -1,0 +1,1 @@
+SELECT COALESCE(nickname, full_name) AS display FROM users;

--- a/tests/fixtures/prefer-coalesce-over-case/valid/different-branches.sql
+++ b/tests/fixtures/prefer-coalesce-over-case/valid/different-branches.sql
@@ -1,0 +1,2 @@
+SELECT CASE WHEN created_at IS NULL THEN 'unknown' ELSE 'set' END AS status
+FROM users;

--- a/tests/fixtures/prefer-coalesce-over-case/valid/multi-arm.sql
+++ b/tests/fixtures/prefer-coalesce-over-case/valid/multi-arm.sql
@@ -1,0 +1,6 @@
+SELECT CASE
+  WHEN nickname IS NULL THEN full_name
+  WHEN length(nickname) = 0 THEN full_name
+  ELSE nickname
+END AS display
+FROM users;

--- a/tests/prefer-coalesce-over-case.test.ts
+++ b/tests/prefer-coalesce-over-case.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-coalesce-over-case.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-coalesce-over-case",
+  rule,
+  "should flag CASE patterns equivalent to COALESCE",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/prefer-coalesce-over-case`, a rule that flags `CASE WHEN x IS NULL THEN fallback ELSE x END` (and the equivalent `IS NOT NULL` mirror) and recommends the equivalent `COALESCE(x, fallback)`. Multi-arm CASE expressions that do more than a null fallback are not flagged.

## Motivation

This pattern is a recurring lint target in PG-using codebases: COALESCE is shorter, evaluates the argument once, and is the form the planner optimizes directly. The rule pairs nicely with the existing prefer-* style rules.

## Changes

- New rule `postgresql/prefer-coalesce-over-case`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/prefer-coalesce-over-case.test.ts` runs fixture-driven tests for both `IS NULL` and `IS NOT NULL` patterns, plus negative cases for plain COALESCE, a `CASE` that returns different constants, and a multi-arm CASE.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->