### PR TITLE
feat: add postgresql/no-having-without-group-by rule

### DIFF
--- a/.changeset/no-having-without-group-by.md
+++ b/.changeset/no-having-without-group-by.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-having-without-group-by` rule: errors when a `SELECT` uses `HAVING` with no `GROUP BY`, which collapses the query to a single aggregate row over the whole table. Enabled at `error` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -741,6 +741,29 @@ SELECT CASE
 END FROM users;
 ```
 
+### `postgresql/no-having-without-group-by`
+
+Errors on a `HAVING` clause that has no accompanying `GROUP BY`. The query is then a single aggregate over the entire table, which is almost always a mistake (the predicate belongs in `WHERE`). PostgreSQL accepts the form, so the planner won't catch it for you.
+
+**Type**: Problem  
+**Recommended**: ✅ Error  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT count(*) FROM users HAVING count(*) > 1;
+```
+
+✅ Correct:
+
+```sql
+SELECT category, count(*) FROM items GROUP BY category HAVING count(*) > 1;
+SELECT count(*) FROM users WHERE active;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -464,6 +464,22 @@ export const rules: RuleMeta[] = [
     ],
     correct: ["SELECT COALESCE(nickname, full_name) FROM users;"],
   },
+  {
+    name: "no-having-without-group-by",
+    description:
+      "Disallow `HAVING` without `GROUP BY`; the predicate belongs in `WHERE`.",
+    longDescription:
+      "PostgreSQL accepts `HAVING` without `GROUP BY` and collapses the query to a single aggregate row over the whole table — almost never what the author meant. If the predicate is row-level, put it in `WHERE`. If it's aggregate-level, add a `GROUP BY`.",
+    type: "problem",
+    recommended: "error",
+    fixable: false,
+    category: "safety",
+    incorrect: ["SELECT count(*) FROM users HAVING count(*) > 1;"],
+    correct: [
+      "SELECT category, count(*) FROM items GROUP BY category HAVING count(*) > 1;",
+      "SELECT count(*) FROM users WHERE active;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noGroupByOrdinal from "./rules/no-group-by-ordinal.js";
+import noHavingWithoutGroupBy from "./rules/no-having-without-group-by.js";
 import noImplicitJoin from "./rules/no-implicit-join.js";
 import noLeadingWildcardLike from "./rules/no-leading-wildcard-like.js";
 import noMoneyType from "./rules/no-money-type.js";
@@ -39,6 +40,7 @@ const rules = {
   "no-drop-table-cascade": noDropTableCascade,
   "no-grant-to-public": noGrantToPublic,
   "no-group-by-ordinal": noGroupByOrdinal,
+  "no-having-without-group-by": noHavingWithoutGroupBy,
   "no-implicit-join": noImplicitJoin,
   "no-leading-wildcard-like": noLeadingWildcardLike,
   "no-money-type": noMoneyType,
@@ -91,6 +93,7 @@ plugin.configs = {
       "postgresql/no-drop-table-cascade": "warn",
       "postgresql/no-grant-to-public": "warn",
       "postgresql/no-group-by-ordinal": "warn",
+      "postgresql/no-having-without-group-by": "error",
       "postgresql/no-implicit-join": "warn",
       "postgresql/no-leading-wildcard-like": "warn",
       "postgresql/no-money-type": "error",

--- a/src/rules/no-having-without-group-by.ts
+++ b/src/rules/no-having-without-group-by.ts
@@ -1,0 +1,35 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `HAVING` without `GROUP BY` — the query aggregates the entire result set, which is almost never the intended shape",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noHavingWithoutGroupBy:
+        "`HAVING` without `GROUP BY` collapses the query to one aggregate row over the whole table. If that is intended, put the predicate in `WHERE`. Otherwise, add a `GROUP BY`.",
+    },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        if (!node.havingClause) return;
+        if (Array.isArray(node.groupClause) && node.groupClause.length > 0)
+          return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noHavingWithoutGroupBy",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-having-without-group-by/invalid/having-without-group-errors.expected.json
+++ b/tests/fixtures/no-having-without-group-by/invalid/having-without-group-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noHavingWithoutGroupBy"
+  }
+]

--- a/tests/fixtures/no-having-without-group-by/invalid/having-without-group.sql
+++ b/tests/fixtures/no-having-without-group-by/invalid/having-without-group.sql
@@ -1,0 +1,1 @@
+SELECT count(*) FROM users HAVING count(*) > 1;

--- a/tests/fixtures/no-having-without-group-by/valid/having-with-group.sql
+++ b/tests/fixtures/no-having-without-group-by/valid/having-with-group.sql
@@ -1,0 +1,1 @@
+SELECT category, count(*) FROM items GROUP BY category HAVING count(*) > 1;

--- a/tests/fixtures/no-having-without-group-by/valid/no-having.sql
+++ b/tests/fixtures/no-having-without-group-by/valid/no-having.sql
@@ -1,0 +1,1 @@
+SELECT count(*) FROM users;

--- a/tests/no-having-without-group-by.test.ts
+++ b/tests/no-having-without-group-by.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-having-without-group-by.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-having-without-group-by",
+  rule,
+  "should disallow HAVING without GROUP BY",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-having-without-group-by`, a rule that errors on `HAVING` without `GROUP BY`. PostgreSQL accepts the form and silently collapses the query to one aggregate row over the whole table — almost always a mistake. Row-level predicates belong in `WHERE`.

## Motivation

`HAVING` without `GROUP BY` is a long-standing SQL footgun: the query "works" but produces a single-row result that doesn't match the author's intent. Catching it at lint time saves a noisy debugging session.

## Changes

- New rule `postgresql/no-having-without-group-by`, enabled at `error` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-having-without-group-by.test.ts` covers the invalid form plus valid cases for `HAVING` paired with `GROUP BY` and a plain SELECT without `HAVING`.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `error`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->