### PR TITLE
feat: add postgresql/no-alter-column-type rule

### DIFF
--- a/.changeset/no-alter-column-type.md
+++ b/.changeset/no-alter-column-type.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-alter-column-type` rule: warns on `ALTER TABLE ... ALTER COLUMN ... TYPE ...`, which may rewrite the entire table under an `ACCESS EXCLUSIVE` lock. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -764,6 +764,30 @@ SELECT category, count(*) FROM items GROUP BY category HAVING count(*) > 1;
 SELECT count(*) FROM users WHERE active;
 ```
 
+### `postgresql/no-alter-column-type`
+
+Warns on `ALTER TABLE ... ALTER COLUMN ... TYPE ...`. PostgreSQL may need to rewrite every row (and every index) to change a column's type, all of it under an `ACCESS EXCLUSIVE` lock that blocks every other reader and writer. For non-trivial tables, add a new column, dual-write, backfill, and swap — or wrap the conversion in a separate, scheduled migration.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+ALTER TABLE users ALTER COLUMN id TYPE bigint;
+```
+
+✅ Correct:
+
+```sql
+-- Phase 1: add a new column, dual-write in app code.
+ALTER TABLE users ADD COLUMN id_new bigint;
+-- Phase 2 (later migration): backfill, swap, drop the old column.
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -480,6 +480,22 @@ export const rules: RuleMeta[] = [
       "SELECT count(*) FROM users WHERE active;",
     ],
   },
+  {
+    name: "no-alter-column-type",
+    description:
+      "Warn on `ALTER COLUMN ... TYPE` — can rewrite the table under ACCESS EXCLUSIVE.",
+    longDescription:
+      "PostgreSQL may need to rewrite every row (and every index) under an `ACCESS EXCLUSIVE` lock to change a column's type. For non-trivial tables, add a new column, dual-write, backfill, and swap — or wrap the conversion in a separate, scheduled migration.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["ALTER TABLE users ALTER COLUMN id TYPE bigint;"],
+    correct: [
+      "ALTER TABLE users ADD COLUMN id_new bigint;",
+      "ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active';",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { ESLint, Linter } from "eslint";
 import postgresqlParser from "postgresql-eslint-parser";
 import { name, version } from "./meta.js";
 import noAddColumnNotNullWithoutDefault from "./rules/no-add-column-not-null-without-default.js";
+import noAlterColumnType from "./rules/no-alter-column-type.js";
 import noCharType from "./rules/no-char-type.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.js";
@@ -34,6 +35,7 @@ import snakeCaseTableName from "./rules/snake-case-table-name.js";
 
 const rules = {
   "no-add-column-not-null-without-default": noAddColumnNotNullWithoutDefault,
+  "no-alter-column-type": noAlterColumnType,
   "no-char-type": noCharType,
   "no-cross-join": noCrossJoin,
   "no-distinct-on-without-order-by": noDistinctOnWithoutOrderBy,
@@ -87,6 +89,7 @@ plugin.configs = {
     },
     rules: {
       "postgresql/no-add-column-not-null-without-default": "error",
+      "postgresql/no-alter-column-type": "warn",
       "postgresql/no-char-type": "warn",
       "postgresql/no-cross-join": "warn",
       "postgresql/no-distinct-on-without-order-by": "error",

--- a/src/rules/no-alter-column-type.ts
+++ b/src/rules/no-alter-column-type.ts
@@ -1,0 +1,33 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `ALTER TABLE ... ALTER COLUMN ... TYPE ...` because it can rewrite the table under an ACCESS EXCLUSIVE lock",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noAlterColumnType:
+        "`ALTER COLUMN ... TYPE` can rewrite the entire table under an ACCESS EXCLUSIVE lock. For non-trivial tables, add a new column, dual-write, backfill, and swap — or use `USING` only for known-safe conversions in a separate migration.",
+    },
+  },
+  create(context) {
+    return {
+      AlterTableCmd(node: Ast.AlterTableCmd) {
+        if (node.subtype !== "AT_AlterColumnType") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noAlterColumnType",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-alter-column-type/invalid/alter-type-errors.expected.json
+++ b/tests/fixtures/no-alter-column-type/invalid/alter-type-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noAlterColumnType"
+  }
+]

--- a/tests/fixtures/no-alter-column-type/invalid/alter-type.sql
+++ b/tests/fixtures/no-alter-column-type/invalid/alter-type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN id TYPE bigint;

--- a/tests/fixtures/no-alter-column-type/valid/add-column.sql
+++ b/tests/fixtures/no-alter-column-type/valid/add-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN id_new bigint;

--- a/tests/fixtures/no-alter-column-type/valid/alter-default.sql
+++ b/tests/fixtures/no-alter-column-type/valid/alter-default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active';

--- a/tests/no-alter-column-type.test.ts
+++ b/tests/no-alter-column-type.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-alter-column-type.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-alter-column-type",
+  rule,
+  "should disallow ALTER COLUMN ... TYPE",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-alter-column-type`, a rule that warns on `ALTER TABLE ... ALTER COLUMN ... TYPE ...`. The operation may rewrite the entire table under an `ACCESS EXCLUSIVE` lock, blocking every other reader and writer.

## Motivation

Type changes are one of the most common causes of unplanned downtime in production migrations. The safer pattern (add column → dual-write → backfill → swap) is well-documented but easy to skip when the tool doesn't push back. This rule joins the existing safety rules around DROP/CASCADE and CREATE INDEX.

## Changes

- New rule `postgresql/no-alter-column-type`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-alter-column-type.test.ts` runs fixture-driven tests for the flagged form plus valid cases (ADD COLUMN, ALTER COLUMN SET DEFAULT).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->