### PR TITLE
feat: add postgresql/no-rename-column rule

### DIFF
--- a/.changeset/no-rename-column.md
+++ b/.changeset/no-rename-column.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-rename-column` rule: warns on `ALTER TABLE ... RENAME COLUMN` because every running app instance that still references the old name errors the moment the migration runs. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -788,6 +788,30 @@ ALTER TABLE users ADD COLUMN id_new bigint;
 -- Phase 2 (later migration): backfill, swap, drop the old column.
 ```
 
+### `postgresql/no-rename-column`
+
+Warns on `ALTER TABLE ... RENAME COLUMN`. The rename completes atomically in the database, but every running app instance that still references the old name starts erroring the moment the migration runs. The safe pattern is add → dual-write → backfill → drop across separate deploys.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+ALTER TABLE users RENAME COLUMN email_address TO email;
+```
+
+✅ Correct:
+
+```sql
+-- Phase 1
+ALTER TABLE users ADD COLUMN email text;
+-- (Backfill, dual-write, drop old column in a later migration.)
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -496,6 +496,19 @@ export const rules: RuleMeta[] = [
       "ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active';",
     ],
   },
+  {
+    name: "no-rename-column",
+    description:
+      "Warn on `RENAME COLUMN` — breaks deployed code reading the old name.",
+    longDescription:
+      "The rename completes atomically in the database, but every running app instance that still references the old name starts erroring the moment the migration runs. Use add → dual-write → backfill → drop across separate deploys.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["ALTER TABLE users RENAME COLUMN email_address TO email;"],
+    correct: ["ALTER TABLE users ADD COLUMN email text;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import noMoneyType from "./rules/no-money-type.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noNotInSubquery from "./rules/no-not-in-subquery.js";
 import noOrderByOrdinal from "./rules/no-order-by-ordinal.js";
+import noRenameColumn from "./rules/no-rename-column.js";
 import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
@@ -49,6 +50,7 @@ const rules = {
   "no-natural-join": noNaturalJoin,
   "no-not-in-subquery": noNotInSubquery,
   "no-order-by-ordinal": noOrderByOrdinal,
+  "no-rename-column": noRenameColumn,
   "no-select-into": noSelectInto,
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
@@ -103,6 +105,7 @@ plugin.configs = {
       "postgresql/no-natural-join": "error",
       "postgresql/no-not-in-subquery": "error",
       "postgresql/no-order-by-ordinal": "warn",
+      "postgresql/no-rename-column": "warn",
       "postgresql/no-select-into": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-truncate-cascade": "warn",

--- a/src/rules/no-rename-column.ts
+++ b/src/rules/no-rename-column.ts
@@ -1,0 +1,37 @@
+import type { Rule } from "eslint";
+
+interface RenameStmtNode {
+  type: "RenameStmt";
+  renameType?: string;
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `ALTER TABLE ... RENAME COLUMN` — every deployed reader of the old name breaks at deploy time",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noRenameColumn:
+        "`RENAME COLUMN` breaks every running app that still selects/inserts by the old name. The safer pattern is to add a new column, dual-write, backfill, and drop the old one across separate deploys.",
+    },
+  },
+  create(context) {
+    return {
+      RenameStmt(node: RenameStmtNode) {
+        if (node.renameType !== "OBJECT_COLUMN") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noRenameColumn",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-rename-column/invalid/rename-column-errors.expected.json
+++ b/tests/fixtures/no-rename-column/invalid/rename-column-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noRenameColumn"
+  }
+]

--- a/tests/fixtures/no-rename-column/invalid/rename-column.sql
+++ b/tests/fixtures/no-rename-column/invalid/rename-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN email_address TO email;

--- a/tests/fixtures/no-rename-column/valid/add-column.sql
+++ b/tests/fixtures/no-rename-column/valid/add-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN email text;

--- a/tests/no-rename-column.test.ts
+++ b/tests/no-rename-column.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-rename-column.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-rename-column", rule, "should disallow RENAME COLUMN");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-rename-column`, a rule that warns on `ALTER TABLE ... RENAME COLUMN`. Every running app instance still reading the old name fails the moment the migration runs.

## Motivation

Renames are a classic source of deploy-time errors when the schema change races the application rollout. Joining the deploy-safety rule family (no-alter-column-type, no-drop-table-cascade, prefer-create-index-concurrently).

## Changes

- New rule `postgresql/no-rename-column`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-rename-column.test.ts` covers the flagged form plus a valid ADD COLUMN case.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->