### PR TITLE
feat: add postgresql/no-drop-column rule

### DIFF
--- a/.changeset/no-drop-column.md
+++ b/.changeset/no-drop-column.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-drop-column` rule: warns on `ALTER TABLE ... DROP COLUMN`, which breaks every running app instance that still references the column. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -835,6 +835,30 @@ CREATE TABLE users (id BIGINT PRIMARY KEY);
 -- Migrate writers, then drop the legacy table in a later deploy.
 ```
 
+### `postgresql/no-drop-column`
+
+Warns on `ALTER TABLE ... DROP COLUMN`. Every running app that still reads the column starts failing the moment the migration runs. The two-step pattern is: stop reading/writing the column in the application and deploy, then drop it in a follow-up migration.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+ALTER TABLE users DROP COLUMN legacy_flag;
+```
+
+✅ Correct:
+
+```sql
+-- Phase 1: remove every read/write of legacy_flag in the app.
+-- Phase 2 (separate deploy): then drop it.
+ALTER TABLE users ADD COLUMN status text;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -522,6 +522,19 @@ export const rules: RuleMeta[] = [
     incorrect: ["ALTER TABLE legacy_users RENAME TO users;"],
     correct: ["CREATE TABLE users (id BIGINT PRIMARY KEY);"],
   },
+  {
+    name: "no-drop-column",
+    description:
+      "Warn on `DROP COLUMN` — breaks every reader still referencing the column.",
+    longDescription:
+      "Every running app instance that still reads the column starts failing the moment the migration runs. The safe pattern is to stop reading/writing the column in the application, deploy, then drop it in a follow-up migration.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["ALTER TABLE users DROP COLUMN legacy_flag;"],
+    correct: ["ALTER TABLE users ADD COLUMN status text;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import noAlterColumnType from "./rules/no-alter-column-type.js";
 import noCharType from "./rules/no-char-type.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.js";
+import noDropColumn from "./rules/no-drop-column.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noGroupByOrdinal from "./rules/no-group-by-ordinal.js";
@@ -41,6 +42,7 @@ const rules = {
   "no-char-type": noCharType,
   "no-cross-join": noCrossJoin,
   "no-distinct-on-without-order-by": noDistinctOnWithoutOrderBy,
+  "no-drop-column": noDropColumn,
   "no-drop-table-cascade": noDropTableCascade,
   "no-grant-to-public": noGrantToPublic,
   "no-group-by-ordinal": noGroupByOrdinal,
@@ -97,6 +99,7 @@ plugin.configs = {
       "postgresql/no-char-type": "warn",
       "postgresql/no-cross-join": "warn",
       "postgresql/no-distinct-on-without-order-by": "error",
+      "postgresql/no-drop-column": "warn",
       "postgresql/no-drop-table-cascade": "warn",
       "postgresql/no-grant-to-public": "warn",
       "postgresql/no-group-by-ordinal": "warn",

--- a/src/rules/no-drop-column.ts
+++ b/src/rules/no-drop-column.ts
@@ -1,0 +1,33 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `ALTER TABLE ... DROP COLUMN` — every reader of the dropped column breaks at deploy time",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDropColumn:
+        "`DROP COLUMN` breaks every running app that still references the column. Roll it out as a two-step migration: stop reading the column in the application, deploy, then drop it in a follow-up release.",
+    },
+  },
+  create(context) {
+    return {
+      AlterTableCmd(node: Ast.AlterTableCmd) {
+        if (node.subtype !== "AT_DropColumn") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noDropColumn",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-drop-column/invalid/drop-column-errors.expected.json
+++ b/tests/fixtures/no-drop-column/invalid/drop-column-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noDropColumn"
+  }
+]

--- a/tests/fixtures/no-drop-column/invalid/drop-column.sql
+++ b/tests/fixtures/no-drop-column/invalid/drop-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN legacy_flag;

--- a/tests/fixtures/no-drop-column/valid/add-column.sql
+++ b/tests/fixtures/no-drop-column/valid/add-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN status text;

--- a/tests/no-drop-column.test.ts
+++ b/tests/no-drop-column.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-drop-column.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-drop-column", rule, "should disallow DROP COLUMN");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-drop-column`, a rule that warns on `ALTER TABLE ... DROP COLUMN`. Every reader of the column breaks the moment the migration runs.

## Motivation

Completes the deploy-safety set alongside `no-rename-column`, `no-rename-table`, and `no-alter-column-type`. Drops should be the last step of a multi-deploy migration.

## Changes

- New rule `postgresql/no-drop-column`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-drop-column.test.ts` covers the flagged form plus a valid ADD COLUMN case.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->