### PR TITLE
feat: add postgresql/prefer-fk-not-valid rule

### DIFF
--- a/.changeset/prefer-fk-not-valid.md
+++ b/.changeset/prefer-fk-not-valid.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-fk-not-valid` rule: warns on `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY (...)` that does not include `NOT VALID`. Validating an FK takes an `ACCESS EXCLUSIVE` lock for the full scan; `NOT VALID` + a separate `VALIDATE CONSTRAINT` only needs `SHARE UPDATE EXCLUSIVE`. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -881,6 +881,33 @@ ALTER TABLE users ALTER COLUMN email DROP NOT NULL;
 ALTER TABLE users ALTER COLUMN status DROP DEFAULT;
 ```
 
+### `postgresql/prefer-fk-not-valid`
+
+Warns on `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY (...)` that does not include `NOT VALID`. Adding a foreign key normally validates every existing row under an `ACCESS EXCLUSIVE` lock that blocks writers for the full scan. The safer pattern is to add the constraint with `NOT VALID` (a fast metadata-only operation) and then `ALTER TABLE ... VALIDATE CONSTRAINT ...` in a separate migration — `VALIDATE` only takes a `SHARE UPDATE EXCLUSIVE` lock.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+ALTER TABLE orders
+  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id);
+```
+
+✅ Correct:
+
+```sql
+ALTER TABLE orders
+  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;
+
+-- Later migration, no exclusive lock:
+ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -548,6 +548,24 @@ export const rules: RuleMeta[] = [
     incorrect: ["ALTER TABLE users ALTER COLUMN email DROP NOT NULL;"],
     correct: ["ALTER TABLE users ALTER COLUMN status DROP DEFAULT;"],
   },
+  {
+    name: "prefer-fk-not-valid",
+    description:
+      "Require `NOT VALID` when adding a foreign key so validation isn't done under ACCESS EXCLUSIVE.",
+    longDescription:
+      "Adding a foreign key normally validates every existing row under an `ACCESS EXCLUSIVE` lock that blocks writers. The safe pattern is to `ADD ... NOT VALID` (metadata-only) and then `VALIDATE CONSTRAINT` in a separate migration; `VALIDATE` only takes a `SHARE UPDATE EXCLUSIVE` lock.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: [
+      "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id);",
+    ],
+    correct: [
+      "ALTER TABLE orders\n  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;",
+      "ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
 import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
+import preferFkNotValid from "./rules/prefer-fk-not-valid.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
 import preferTextOverVarchar from "./rules/prefer-text-over-varchar.js";
@@ -63,6 +64,7 @@ const rules = {
   "no-truncate-cascade": noTruncateCascade,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
   "prefer-create-index-concurrently": preferCreateIndexConcurrently,
+  "prefer-fk-not-valid": preferFkNotValid,
   "prefer-identity-over-serial": preferIdentityOverSerial,
   "prefer-jsonb-over-json": preferJsonbOverJson,
   "prefer-text-over-varchar": preferTextOverVarchar,
@@ -119,6 +121,7 @@ plugin.configs = {
       "postgresql/no-syntax-error": "error",
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",
+      "postgresql/prefer-fk-not-valid": "warn",
       "postgresql/prefer-identity-over-serial": "warn",
       "postgresql/prefer-jsonb-over-json": "warn",
       "postgresql/prefer-text-over-varchar": "warn",

--- a/src/rules/prefer-fk-not-valid.ts
+++ b/src/rules/prefer-fk-not-valid.ts
@@ -1,0 +1,49 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { isConstraint } from "../utils/ast.js";
+
+const isFkConstraint = (def: unknown): def is Ast.Constraint => {
+  if (!isConstraint(def)) return false;
+  return def.contype === "CONSTR_FOREIGN";
+};
+
+// `NOT VALID` causes the parser to set `skip_validation: true`; without
+// `NOT VALID`, the parser sets `initially_valid: true`.
+const skipsValidation = (constraint: Ast.Constraint): boolean => {
+  const c = constraint as Ast.Constraint & { skip_validation?: boolean };
+  return c.skip_validation === true;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require `ALTER TABLE ... ADD FOREIGN KEY ...` to use `NOT VALID` so validation does not take an ACCESS EXCLUSIVE lock for the full scan",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferFkNotValid:
+        "Adding a foreign key without `NOT VALID` validates every existing row under an `ACCESS EXCLUSIVE` lock that blocks writers. Use `ADD CONSTRAINT ... FOREIGN KEY (...) REFERENCES ... NOT VALID`, then `ALTER TABLE ... VALIDATE CONSTRAINT` in a separate migration (`VALIDATE` only takes a `SHARE UPDATE EXCLUSIVE` lock).",
+    },
+  },
+  create(context) {
+    return {
+      AlterTableCmd(node: Ast.AlterTableCmd) {
+        if (node.subtype !== "AT_AddConstraint") return;
+        const def = node.def;
+        if (!isFkConstraint(def)) return;
+        if (skipsValidation(def)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "preferFkNotValid",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-fk-not-valid/invalid/add-fk-errors.expected.json
+++ b/tests/fixtures/prefer-fk-not-valid/invalid/add-fk-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferFkNotValid"
+  }
+]

--- a/tests/fixtures/prefer-fk-not-valid/invalid/add-fk.sql
+++ b/tests/fixtures/prefer-fk-not-valid/invalid/add-fk.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id);

--- a/tests/fixtures/prefer-fk-not-valid/valid/add-check-without-fk.sql
+++ b/tests/fixtures/prefer-fk-not-valid/valid/add-check-without-fk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD CONSTRAINT positive_amount CHECK (amount > 0);

--- a/tests/fixtures/prefer-fk-not-valid/valid/add-fk-not-valid.sql
+++ b/tests/fixtures/prefer-fk-not-valid/valid/add-fk-not-valid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+  ADD CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;

--- a/tests/fixtures/prefer-fk-not-valid/valid/validate.sql
+++ b/tests/fixtures/prefer-fk-not-valid/valid/validate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;

--- a/tests/prefer-fk-not-valid.test.ts
+++ b/tests/prefer-fk-not-valid.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-fk-not-valid.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-fk-not-valid",
+  rule,
+  "should require NOT VALID when adding a foreign key",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/prefer-fk-not-valid`, a rule that warns on `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY (...)` that does not include `NOT VALID`. Validating a foreign key normally requires an ACCESS EXCLUSIVE lock that blocks writers for the full scan; `NOT VALID` + a separate `VALIDATE CONSTRAINT` only needs SHARE UPDATE EXCLUSIVE.

## Motivation

Migration playbook from PG production guides (Squawk, GitLab DB style guide, pganalyze "safe migrations"). Joins the existing safety rules around concurrent index creation and table drops.

## Changes

- New rule `postgresql/prefer-fk-not-valid`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/prefer-fk-not-valid.test.ts` covers the flagged form, the `NOT VALID` variant, the `VALIDATE CONSTRAINT` follow-up, and an unrelated CHECK constraint (negative case).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->