### PR TITLE
feat: add postgresql/require-named-constraint rule

### DIFF
--- a/.changeset/require-named-constraint.md
+++ b/.changeset/require-named-constraint.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/require-named-constraint` rule: warns when a table-level `CHECK`, `UNIQUE`, `FOREIGN KEY`, or `EXCLUSION` constraint is declared without an explicit `CONSTRAINT <name>`. Auto-generated constraint names vary across environments and make later `DROP CONSTRAINT` / `ALTER CONSTRAINT` statements brittle. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -908,6 +908,35 @@ ALTER TABLE orders
 ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;
 ```
 
+### `postgresql/require-named-constraint`
+
+Warns when a table-level `CHECK`, `UNIQUE`, `FOREIGN KEY`, or `EXCLUSION` constraint is declared without an explicit `CONSTRAINT <name>`. PostgreSQL invents a name for unnamed constraints (e.g., `items_code_key`); the generated name varies subtly across environments and migration tools, which makes later `DROP CONSTRAINT` / `ALTER CONSTRAINT` statements brittle. Column-level `NOT NULL` and `PRIMARY KEY` are allowed without names — the auto-generated names there are stable.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE TABLE items (id int, code text, UNIQUE (code));
+ALTER TABLE items ADD CHECK (length(code) > 0);
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE items (
+  id int,
+  code text,
+  CONSTRAINT items_code_unique UNIQUE (code)
+);
+
+ALTER TABLE items ADD CONSTRAINT items_code_non_empty CHECK (length(code) > 0);
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -566,6 +566,25 @@ export const rules: RuleMeta[] = [
       "ALTER TABLE orders VALIDATE CONSTRAINT orders_customer_fk;",
     ],
   },
+  {
+    name: "require-named-constraint",
+    description:
+      "Require explicit names on CHECK / UNIQUE / FK / EXCLUSION constraints.",
+    longDescription:
+      "PostgreSQL invents a name for unnamed constraints, but the generated name varies subtly across environments and migration tools, which makes later `DROP CONSTRAINT` / `ALTER CONSTRAINT` statements brittle. Column-level `NOT NULL` and `PRIMARY KEY` are allowed without explicit names.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "schema",
+    incorrect: [
+      "CREATE TABLE items (id int, code text, UNIQUE (code));",
+      "ALTER TABLE items ADD CHECK (length(code) > 0);",
+    ],
+    correct: [
+      "CREATE TABLE items (\n  id int,\n  code text,\n  CONSTRAINT items_code_unique UNIQUE (code)\n);",
+      "ALTER TABLE items ADD CONSTRAINT items_code_non_empty CHECK (length(code) > 0);",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
 import preferTextOverVarchar from "./rules/prefer-text-over-varchar.js";
 import preferTimestamptz from "./rules/prefer-timestamptz.js";
 import requireLimit from "./rules/require-limit.js";
+import requireNamedConstraint from "./rules/require-named-constraint.js";
 import requirePrimaryKey from "./rules/require-primary-key.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
@@ -70,6 +71,7 @@ const rules = {
   "prefer-text-over-varchar": preferTextOverVarchar,
   "prefer-timestamptz": preferTimestamptz,
   "require-limit": requireLimit,
+  "require-named-constraint": requireNamedConstraint,
   "require-primary-key": requirePrimaryKey,
   "require-where-in-delete": requireWhereInDelete,
   "require-where-in-update": requireWhereInUpdate,
@@ -127,6 +129,7 @@ plugin.configs = {
       "postgresql/prefer-text-over-varchar": "warn",
       "postgresql/prefer-timestamptz": "warn",
       "postgresql/require-limit": "warn",
+      "postgresql/require-named-constraint": "warn",
       "postgresql/require-primary-key": "warn",
       "postgresql/require-where-in-delete": "error",
       "postgresql/require-where-in-update": "error",

--- a/src/rules/require-named-constraint.ts
+++ b/src/rules/require-named-constraint.ts
@@ -1,0 +1,67 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { isConstraint } from "../utils/ast.js";
+
+const NAMED_CONSTRAINT_TYPES = new Set<string>([
+  "CONSTR_CHECK",
+  "CONSTR_UNIQUE",
+  "CONSTR_FOREIGN",
+  "CONSTR_EXCLUSION",
+]);
+
+const isUnnamedNamedKind = (c: Ast.Constraint): boolean => {
+  const contype = c.contype;
+  if (typeof contype !== "string") return false;
+  if (!NAMED_CONSTRAINT_TYPES.has(contype)) return false;
+  const named = (c as Ast.Constraint & { conname?: unknown }).conname;
+  return typeof named !== "string" || named.length === 0;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require an explicit name on table-level CHECK, UNIQUE, FOREIGN KEY, and EXCLUSION constraints",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      requireNamedConstraint:
+        "Table-level CHECK / UNIQUE / FOREIGN KEY / EXCLUSION constraints should be named with `CONSTRAINT <name>`. Auto-generated names are unpredictable across environments and make later `DROP CONSTRAINT` / `ALTER CONSTRAINT` migrations brittle.",
+    },
+  },
+  create(context) {
+    return {
+      // Table-level constraint inside `CREATE TABLE (..., CHECK (...))`.
+      CreateStmt(node: Ast.CreateStmt) {
+        const elts = node.tableElts;
+        if (!Array.isArray(elts)) return;
+        for (const elt of elts) {
+          if (!isConstraint(elt)) continue;
+          if (!isUnnamedNamedKind(elt)) continue;
+          context.report({
+            node: elt as unknown as Rule.Node,
+            messageId: "requireNamedConstraint",
+          });
+        }
+      },
+      // `ALTER TABLE ... ADD CONSTRAINT? ... ` — also catches the bare `ADD CHECK`
+      // / `ADD UNIQUE` / `ADD FOREIGN KEY` forms that omit the constraint name.
+      AlterTableCmd(node: Ast.AlterTableCmd) {
+        if (node.subtype !== "AT_AddConstraint") return;
+        const def = node.def;
+        if (!isConstraint(def)) return;
+        if (!isUnnamedNamedKind(def)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "requireNamedConstraint",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/require-named-constraint/invalid/alter-add-check-errors.expected.json
+++ b/tests/fixtures/require-named-constraint/invalid/alter-add-check-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "requireNamedConstraint"
+  }
+]

--- a/tests/fixtures/require-named-constraint/invalid/alter-add-check.sql
+++ b/tests/fixtures/require-named-constraint/invalid/alter-add-check.sql
@@ -1,0 +1,1 @@
+ALTER TABLE items ADD CHECK (length(code) > 0);

--- a/tests/fixtures/require-named-constraint/invalid/create-table-unique-errors.expected.json
+++ b/tests/fixtures/require-named-constraint/invalid/create-table-unique-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "requireNamedConstraint"
+  }
+]

--- a/tests/fixtures/require-named-constraint/invalid/create-table-unique.sql
+++ b/tests/fixtures/require-named-constraint/invalid/create-table-unique.sql
@@ -1,0 +1,1 @@
+CREATE TABLE items (id int, code text, UNIQUE (code));

--- a/tests/fixtures/require-named-constraint/valid/column-not-null.sql
+++ b/tests/fixtures/require-named-constraint/valid/column-not-null.sql
@@ -1,0 +1,2 @@
+-- NOT NULL on a column is allowed without an explicit name.
+CREATE TABLE items (id int PRIMARY KEY, code text NOT NULL);

--- a/tests/fixtures/require-named-constraint/valid/named-add-fk.sql
+++ b/tests/fixtures/require-named-constraint/valid/named-add-fk.sql
@@ -1,0 +1,3 @@
+ALTER TABLE orders
+  ADD CONSTRAINT orders_customer_fk
+  FOREIGN KEY (customer_id) REFERENCES customers (id) NOT VALID;

--- a/tests/fixtures/require-named-constraint/valid/named-unique.sql
+++ b/tests/fixtures/require-named-constraint/valid/named-unique.sql
@@ -1,0 +1,5 @@
+CREATE TABLE items (
+  id int,
+  code text,
+  CONSTRAINT items_code_unique UNIQUE (code)
+);

--- a/tests/require-named-constraint.test.ts
+++ b/tests/require-named-constraint.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/require-named-constraint.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "require-named-constraint",
+  rule,
+  "should require an explicit constraint name",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/require-named-constraint`, a rule that requires explicit names on table-level `CHECK`, `UNIQUE`, `FOREIGN KEY`, and `EXCLUSION` constraints. PostgreSQL invents a name otherwise, but the generated name varies across environments and migration tools — later `DROP CONSTRAINT` / `ALTER CONSTRAINT` statements become brittle.

## Motivation

A long-standing recommendation in PG schema style guides (Postgres Wiki, GitLab DB style guide). Column-level NOT NULL / PRIMARY KEY remain allowed without explicit names since their generated names are stable.

## Changes

- New rule `postgresql/require-named-constraint`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/require-named-constraint.test.ts` covers an unnamed `UNIQUE` inside `CREATE TABLE`, an unnamed `ADD CHECK`, plus valid named variants and a column-level `NOT NULL` case.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->