### PR TITLE
feat: add postgresql/no-unlogged-table rule

### DIFF
--- a/.changeset/no-unlogged-table.md
+++ b/.changeset/no-unlogged-table.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-unlogged-table` rule: warns on `CREATE UNLOGGED TABLE` because unlogged tables are truncated on crash, not replicated, and not restored from base backups. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -937,6 +937,28 @@ CREATE TABLE items (
 ALTER TABLE items ADD CONSTRAINT items_code_non_empty CHECK (length(code) > 0);
 ```
 
+### `postgresql/no-unlogged-table`
+
+Warns on `CREATE UNLOGGED TABLE`. Unlogged tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache-style table is genuinely what you want, document it explicitly and disable this rule for that file.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE session_cache (id text PRIMARY KEY);
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -585,6 +585,19 @@ export const rules: RuleMeta[] = [
       "ALTER TABLE items ADD CONSTRAINT items_code_non_empty CHECK (length(code) > 0);",
     ],
   },
+  {
+    name: "no-unlogged-table",
+    description:
+      "Warn on `CREATE UNLOGGED TABLE` — data is lost on crash and not replicated.",
+    longDescription:
+      "`UNLOGGED` tables skip WAL: truncated on crash, not replicated to standbys, not restored from base backups. If a cache-style table is genuinely what you want, document it and disable the rule on that file.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);"],
+    correct: ["CREATE TABLE session_cache (id text PRIMARY KEY);"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
+import noUnloggedTable from "./rules/no-unlogged-table.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
 import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import preferFkNotValid from "./rules/prefer-fk-not-valid.js";
@@ -63,6 +64,7 @@ const rules = {
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
   "no-truncate-cascade": noTruncateCascade,
+  "no-unlogged-table": noUnloggedTable,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
   "prefer-create-index-concurrently": preferCreateIndexConcurrently,
   "prefer-fk-not-valid": preferFkNotValid,
@@ -122,6 +124,7 @@ plugin.configs = {
       "postgresql/no-select-into": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-truncate-cascade": "warn",
+      "postgresql/no-unlogged-table": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",
       "postgresql/prefer-fk-not-valid": "warn",
       "postgresql/prefer-identity-over-serial": "warn",

--- a/src/rules/no-unlogged-table.ts
+++ b/src/rules/no-unlogged-table.ts
@@ -1,0 +1,36 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `CREATE UNLOGGED TABLE` because unlogged tables are truncated on crash and not replicated",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noUnloggedTable:
+        "`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file.",
+    },
+  },
+  create(context) {
+    return {
+      CreateStmt(node: Ast.CreateStmt) {
+        const relation = node.relation as
+          | (Ast.RangeVar & { relpersistence?: string })
+          | undefined;
+        if (relation?.relpersistence !== "u") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noUnloggedTable",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-unlogged-table/invalid/unlogged-errors.expected.json
+++ b/tests/fixtures/no-unlogged-table/invalid/unlogged-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noUnloggedTable"
+  }
+]

--- a/tests/fixtures/no-unlogged-table/invalid/unlogged.sql
+++ b/tests/fixtures/no-unlogged-table/invalid/unlogged.sql
@@ -1,0 +1,1 @@
+CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);

--- a/tests/fixtures/no-unlogged-table/valid/persistent.sql
+++ b/tests/fixtures/no-unlogged-table/valid/persistent.sql
@@ -1,0 +1,1 @@
+CREATE TABLE session_cache (id text PRIMARY KEY);

--- a/tests/no-unlogged-table.test.ts
+++ b/tests/no-unlogged-table.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-unlogged-table.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-unlogged-table", rule, "should disallow CREATE UNLOGGED TABLE");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-unlogged-table`, a rule that warns on `CREATE UNLOGGED TABLE`. Unlogged tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups.

## Motivation

Unlogged tables are an easy footgun for developers who reach for them as a "fast" option without understanding the durability tradeoff. Joining the existing data-safety rule family.

## Changes

- New rule `postgresql/no-unlogged-table`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-unlogged-table.test.ts` covers the flagged form plus a valid persistent-table case.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->