### PR TITLE
feat: add postgresql/no-temporary-table rule

### DIFF
--- a/.changeset/no-temporary-table.md
+++ b/.changeset/no-temporary-table.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-temporary-table` rule: warns on `CREATE TEMP/TEMPORARY TABLE` in versioned SQL because temporary tables exist only for the current session and almost never belong in migration files. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -959,6 +959,28 @@ CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);
 CREATE TABLE session_cache (id text PRIMARY KEY);
 ```
 
+### `postgresql/no-temporary-table`
+
+Warns on `CREATE TEMP TABLE` / `CREATE TEMPORARY TABLE`. Temporary tables exist only for the current session and disappear when the connection closes — they almost never belong in versioned SQL. If session-scoped scratch storage is genuinely needed, build it from application code.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE TEMP TABLE staging (id int);
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE staging (id int);
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -598,6 +598,19 @@ export const rules: RuleMeta[] = [
     incorrect: ["CREATE UNLOGGED TABLE session_cache (id text PRIMARY KEY);"],
     correct: ["CREATE TABLE session_cache (id text PRIMARY KEY);"],
   },
+  {
+    name: "no-temporary-table",
+    description:
+      "Warn on `CREATE TEMP / TEMPORARY TABLE` in versioned SQL.",
+    longDescription:
+      "Temporary tables exist only for the current session, so they almost never belong in versioned SQL. If session-scoped scratch storage is required, build it from application code.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["CREATE TEMP TABLE staging (id int);"],
+    correct: ["CREATE TABLE staging (id int);"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -600,8 +600,7 @@ export const rules: RuleMeta[] = [
   },
   {
     name: "no-temporary-table",
-    description:
-      "Warn on `CREATE TEMP / TEMPORARY TABLE` in versioned SQL.",
+    description: "Warn on `CREATE TEMP / TEMPORARY TABLE` in versioned SQL.",
     longDescription:
       "Temporary tables exist only for the current session, so they almost never belong in versioned SQL. If session-scoped scratch storage is required, build it from application code.",
     type: "suggestion",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import noRenameTable from "./rules/no-rename-table.js";
 import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
+import noTemporaryTable from "./rules/no-temporary-table.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import noUnloggedTable from "./rules/no-unlogged-table.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
@@ -63,6 +64,7 @@ const rules = {
   "no-select-into": noSelectInto,
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
+  "no-temporary-table": noTemporaryTable,
   "no-truncate-cascade": noTruncateCascade,
   "no-unlogged-table": noUnloggedTable,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
@@ -123,6 +125,7 @@ plugin.configs = {
       "postgresql/no-rename-table": "warn",
       "postgresql/no-select-into": "warn",
       "postgresql/no-syntax-error": "error",
+      "postgresql/no-temporary-table": "warn",
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/no-unlogged-table": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",

--- a/src/rules/no-temporary-table.ts
+++ b/src/rules/no-temporary-table.ts
@@ -1,0 +1,36 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `CREATE TEMPORARY TABLE` in versioned SQL — temp tables exist for the session only and rarely belong in migration files",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noTemporaryTable:
+        "`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier.",
+    },
+  },
+  create(context) {
+    return {
+      CreateStmt(node: Ast.CreateStmt) {
+        const relation = node.relation as
+          | (Ast.RangeVar & { relpersistence?: string })
+          | undefined;
+        if (relation?.relpersistence !== "t") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noTemporaryTable",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-temporary-table/invalid/temp-errors.expected.json
+++ b/tests/fixtures/no-temporary-table/invalid/temp-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noTemporaryTable"
+  }
+]

--- a/tests/fixtures/no-temporary-table/invalid/temp.sql
+++ b/tests/fixtures/no-temporary-table/invalid/temp.sql
@@ -1,0 +1,1 @@
+CREATE TEMP TABLE staging (id int);

--- a/tests/fixtures/no-temporary-table/valid/persistent.sql
+++ b/tests/fixtures/no-temporary-table/valid/persistent.sql
@@ -1,0 +1,1 @@
+CREATE TABLE staging (id int);

--- a/tests/no-temporary-table.test.ts
+++ b/tests/no-temporary-table.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-temporary-table.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-temporary-table",
+  rule,
+  "should disallow CREATE TEMPORARY TABLE",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-temporary-table`, a rule that warns on `CREATE TEMP/TEMPORARY TABLE` in versioned SQL. Temp tables exist only for the current session; if they end up in a migration file it's almost always a mistake.

## Motivation

Companion to `no-unlogged-table`. Both targets are kinds of "non-persistent" tables that occasionally slip into migration files by accident and confuse the reader.

## Changes

- New rule `postgresql/no-temporary-table`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-temporary-table.test.ts` covers the flagged form and a valid persistent-table case.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->