### PR TITLE
feat: add postgresql/no-numeric-without-precision rule

### DIFF
--- a/.changeset/no-numeric-without-precision.md
+++ b/.changeset/no-numeric-without-precision.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-numeric-without-precision` rule: warns on bare `NUMERIC` / `DECIMAL` column declarations and recommends declaring an explicit `NUMERIC(precision, scale)`. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -981,6 +981,29 @@ CREATE TEMP TABLE staging (id int);
 CREATE TABLE staging (id int);
 ```
 
+### `postgresql/no-numeric-without-precision`
+
+Warns on `NUMERIC` (and the `DECIMAL` synonym) declared without an explicit precision and scale. Bare `NUMERIC` accepts unbounded magnitude — useful only if you really do mean "arbitrary precision," which is rarely the case in application schemas. Declare `NUMERIC(precision, scale)` so the column documents the value's domain.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE TABLE products (price numeric);
+CREATE TABLE products (price decimal);
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE products (price numeric(10, 2));
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -610,6 +610,22 @@ export const rules: RuleMeta[] = [
     incorrect: ["CREATE TEMP TABLE staging (id int);"],
     correct: ["CREATE TABLE staging (id int);"],
   },
+  {
+    name: "no-numeric-without-precision",
+    description:
+      "Require an explicit precision and scale on `NUMERIC` / `DECIMAL` columns.",
+    longDescription:
+      "Bare `NUMERIC` accepts unbounded magnitude — useful only if you really do mean 'arbitrary precision', which is rarely the case in application schemas. Declare `NUMERIC(precision, scale)` so the column documents its domain.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "schema",
+    incorrect: [
+      "CREATE TABLE products (price numeric);",
+      "CREATE TABLE products (price decimal);",
+    ],
+    correct: ["CREATE TABLE products (price numeric(10, 2));"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import noLeadingWildcardLike from "./rules/no-leading-wildcard-like.js";
 import noMoneyType from "./rules/no-money-type.js";
 import noNaturalJoin from "./rules/no-natural-join.js";
 import noNotInSubquery from "./rules/no-not-in-subquery.js";
+import noNumericWithoutPrecision from "./rules/no-numeric-without-precision.js";
 import noOrderByOrdinal from "./rules/no-order-by-ordinal.js";
 import noRenameColumn from "./rules/no-rename-column.js";
 import noRenameTable from "./rules/no-rename-table.js";
@@ -58,6 +59,7 @@ const rules = {
   "no-money-type": noMoneyType,
   "no-natural-join": noNaturalJoin,
   "no-not-in-subquery": noNotInSubquery,
+  "no-numeric-without-precision": noNumericWithoutPrecision,
   "no-order-by-ordinal": noOrderByOrdinal,
   "no-rename-column": noRenameColumn,
   "no-rename-table": noRenameTable,
@@ -120,6 +122,7 @@ plugin.configs = {
       "postgresql/no-money-type": "error",
       "postgresql/no-natural-join": "error",
       "postgresql/no-not-in-subquery": "error",
+      "postgresql/no-numeric-without-precision": "warn",
       "postgresql/no-order-by-ordinal": "warn",
       "postgresql/no-rename-column": "warn",
       "postgresql/no-rename-table": "warn",

--- a/src/rules/no-numeric-without-precision.ts
+++ b/src/rules/no-numeric-without-precision.ts
@@ -1,0 +1,41 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
+
+const hasTypmods = (typeName: unknown): boolean => {
+  if (typeof typeName !== "object" || typeName === null) return false;
+  const mods = (typeName as { typmods?: unknown }).typmods;
+  return Array.isArray(mods) && mods.length > 0;
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require an explicit precision (and scale) on `NUMERIC` / `DECIMAL` columns",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNumericWithoutPrecision:
+        "`NUMERIC` / `DECIMAL` without precision accepts unbounded magnitude and rejects nothing — it's a missed opportunity to encode the column's domain. Declare `NUMERIC(precision, scale)`.",
+    },
+  },
+  create(context) {
+    return {
+      ColumnDef(node: Ast.ColumnDef) {
+        if (getTypeName(node.typeName) !== "numeric") return;
+        if (hasTypmods(node.typeName)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noNumericWithoutPrecision",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-numeric-without-precision/invalid/bare-decimal-errors.expected.json
+++ b/tests/fixtures/no-numeric-without-precision/invalid/bare-decimal-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noNumericWithoutPrecision"
+  }
+]

--- a/tests/fixtures/no-numeric-without-precision/invalid/bare-decimal.sql
+++ b/tests/fixtures/no-numeric-without-precision/invalid/bare-decimal.sql
@@ -1,0 +1,1 @@
+CREATE TABLE products (price decimal);

--- a/tests/fixtures/no-numeric-without-precision/invalid/bare-numeric-errors.expected.json
+++ b/tests/fixtures/no-numeric-without-precision/invalid/bare-numeric-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noNumericWithoutPrecision"
+  }
+]

--- a/tests/fixtures/no-numeric-without-precision/invalid/bare-numeric.sql
+++ b/tests/fixtures/no-numeric-without-precision/invalid/bare-numeric.sql
@@ -1,0 +1,1 @@
+CREATE TABLE products (price numeric);

--- a/tests/fixtures/no-numeric-without-precision/valid/int-column.sql
+++ b/tests/fixtures/no-numeric-without-precision/valid/int-column.sql
@@ -1,0 +1,1 @@
+CREATE TABLE products (id bigint PRIMARY KEY);

--- a/tests/fixtures/no-numeric-without-precision/valid/with-precision.sql
+++ b/tests/fixtures/no-numeric-without-precision/valid/with-precision.sql
@@ -1,0 +1,1 @@
+CREATE TABLE products (price numeric(10,2));

--- a/tests/no-numeric-without-precision.test.ts
+++ b/tests/no-numeric-without-precision.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-numeric-without-precision.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-numeric-without-precision",
+  rule,
+  "should require precision on NUMERIC/DECIMAL",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-numeric-without-precision`, a rule that warns on bare `NUMERIC` / `DECIMAL` column declarations. The column accepts unbounded magnitude — usually a missed opportunity to encode the value's domain.

## Motivation

Unbounded `NUMERIC` is a recurring fingerprint of schemas that were translated mechanically from another database (where `DECIMAL` had different defaults). Catching it at lint time pushes contributors to think about scale up front.

## Changes

- New rule `postgresql/no-numeric-without-precision`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-numeric-without-precision.test.ts` covers bare `NUMERIC`, bare `DECIMAL` (treated by the parser as `numeric`), and valid `numeric(10,2)` / bigint cases.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->