### PR TITLE
feat: add postgresql/no-time-type rule

### DIFF
--- a/.changeset/no-time-type.md
+++ b/.changeset/no-time-type.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-time-type` rule: warns on `TIME` and `TIME WITH TIME ZONE` (`timetz`) columns because they rarely model real-world values correctly. Use `timestamptz` for points in time, `interval` for durations, or `text` for a display value. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,30 @@ CREATE TABLE products (price decimal);
 CREATE TABLE products (price numeric(10, 2));
 ```
 
+### `postgresql/no-time-type`
+
+Warns on `TIME` and `TIME WITH TIME ZONE` (`timetz`) columns. `time` has no date and cannot disambiguate around DST transitions; `timetz` stores an offset that is meaningless without a date. Use `timestamptz` for points in time, `interval` for durations, or `text` if all you really need is a display value.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE TABLE shifts (id int, start_at time);
+CREATE TABLE shifts (id int, start_at timetz);
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE shifts (id int, start_at timestamptz);
+CREATE TABLE jobs (id int, duration interval);
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -626,6 +626,25 @@ export const rules: RuleMeta[] = [
     ],
     correct: ["CREATE TABLE products (price numeric(10, 2));"],
   },
+  {
+    name: "no-time-type",
+    description:
+      "Disallow `TIME` / `TIMETZ` columns; they rarely model real values correctly.",
+    longDescription:
+      "`time` has no date so cannot disambiguate around DST transitions; `timetz` stores an offset that is meaningless without a date. Use `timestamptz` for points in time, `interval` for durations, or `text` if all you need is a display value.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "schema",
+    incorrect: [
+      "CREATE TABLE shifts (id int, start_at time);",
+      "CREATE TABLE shifts (id int, start_at timetz);",
+    ],
+    correct: [
+      "CREATE TABLE shifts (id int, start_at timestamptz);",
+      "CREATE TABLE jobs (id int, duration interval);",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTemporaryTable from "./rules/no-temporary-table.js";
+import noTimeType from "./rules/no-time-type.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import noUnloggedTable from "./rules/no-unlogged-table.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
@@ -67,6 +68,7 @@ const rules = {
   "no-select-star": noSelectStar,
   "no-syntax-error": noSyntaxError,
   "no-temporary-table": noTemporaryTable,
+  "no-time-type": noTimeType,
   "no-truncate-cascade": noTruncateCascade,
   "no-unlogged-table": noUnloggedTable,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
@@ -129,6 +131,7 @@ plugin.configs = {
       "postgresql/no-select-into": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-temporary-table": "warn",
+      "postgresql/no-time-type": "warn",
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/no-unlogged-table": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",

--- a/src/rules/no-time-type.ts
+++ b/src/rules/no-time-type.ts
@@ -1,0 +1,38 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName } from "../utils/ast.js";
+
+const TIME_TYPES = new Set(["time", "timetz"]);
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `TIME` / `TIME WITH TIME ZONE` columns; they rarely model a real-world value correctly",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noTimeType:
+        "`TIME` and `TIME WITH TIME ZONE` rarely model anything correctly: `time` has no date so cannot disambiguate around DST, and `timetz` stores an offset that is meaningless without a date. Use `timestamptz` for points in time, `interval` for durations, or store an opaque `text` if all you need is a display value.",
+    },
+  },
+  create(context) {
+    return {
+      ColumnDef(node: Ast.ColumnDef) {
+        const t = getTypeName(node.typeName);
+        if (typeof t !== "string") return;
+        if (!TIME_TYPES.has(t)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noTimeType",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-time-type/invalid/time-errors.expected.json
+++ b/tests/fixtures/no-time-type/invalid/time-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noTimeType"
+  }
+]

--- a/tests/fixtures/no-time-type/invalid/time.sql
+++ b/tests/fixtures/no-time-type/invalid/time.sql
@@ -1,0 +1,1 @@
+CREATE TABLE shifts (id int, start_at time);

--- a/tests/fixtures/no-time-type/invalid/timetz-errors.expected.json
+++ b/tests/fixtures/no-time-type/invalid/timetz-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noTimeType"
+  }
+]

--- a/tests/fixtures/no-time-type/invalid/timetz.sql
+++ b/tests/fixtures/no-time-type/invalid/timetz.sql
@@ -1,0 +1,1 @@
+CREATE TABLE shifts (id int, start_at timetz);

--- a/tests/fixtures/no-time-type/valid/interval.sql
+++ b/tests/fixtures/no-time-type/valid/interval.sql
@@ -1,0 +1,1 @@
+CREATE TABLE jobs (id int, duration interval);

--- a/tests/fixtures/no-time-type/valid/timestamptz.sql
+++ b/tests/fixtures/no-time-type/valid/timestamptz.sql
@@ -1,0 +1,1 @@
+CREATE TABLE shifts (id int, start_at timestamptz);

--- a/tests/no-time-type.test.ts
+++ b/tests/no-time-type.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-time-type.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-time-type", rule, "should disallow TIME / TIMETZ columns");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-time-type`, a rule that warns on `TIME` and `TIME WITH TIME ZONE` (`timetz`) columns. Neither models a real-world value reliably.

## Motivation

`time` cannot reason about DST; `timetz` is famously broken because an offset alone — without a date — does not determine the actual UTC time. The PG docs themselves call `timetz` "of dubious value". Companion to the existing `prefer-timestamptz` rule.

## Changes

- New rule `postgresql/no-time-type`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-time-type.test.ts` covers `time`, `timetz`, and the valid alternatives `timestamptz` and `interval`.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->