### PR TITLE
feat: add postgresql/no-set-search-path rule

### DIFF
--- a/.changeset/no-set-search-path.md
+++ b/.changeset/no-set-search-path.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-set-search-path` rule: warns on `SET search_path = ...` in versioned SQL because name resolution that depends on session state is a known footgun for SECURITY DEFINER functions and CREATE statements. Qualify identifiers with their schema instead. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,28 @@ ALTER TABLE users VALIDATE CONSTRAINT users_email_not_null;
 -- Phase 3 (optional): now `SET NOT NULL` is instant.
 ```
 
+### `postgresql/no-set-search-path`
+
+Warns on `SET search_path = ...` in versioned SQL. The statement changes name resolution for the rest of the session and is a known footgun: a security-definer function written under one search_path may run under another in production, and `CREATE TABLE foo` may target a schema you didn't intend. Qualify identifiers (`audit.events`, `public.users`) instead.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SET search_path TO audit, public;
+```
+
+✅ Correct:
+
+```sql
+SELECT id FROM audit.events;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -660,6 +660,19 @@ export const rules: RuleMeta[] = [
       "ALTER TABLE users VALIDATE CONSTRAINT users_email_not_null;",
     ],
   },
+  {
+    name: "no-set-search-path",
+    description:
+      "Disallow `SET search_path` in versioned SQL; qualify identifiers instead.",
+    longDescription:
+      "`SET search_path` makes name resolution depend on session state — a known footgun for SECURITY DEFINER functions and `CREATE TABLE foo` statements that silently target a different schema. Qualify identifiers (`audit.events`, `public.users`) instead.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["SET search_path TO audit, public;"],
+    correct: ["SELECT id FROM audit.events;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import noRenameTable from "./rules/no-rename-table.js";
 import noSelectInto from "./rules/no-select-into.js";
 import noSelectStar from "./rules/no-select-star.js";
 import noSetNotNull from "./rules/no-set-not-null.js";
+import noSetSearchPath from "./rules/no-set-search-path.js";
 import noSyntaxError from "./rules/no-syntax-error.js";
 import noTemporaryTable from "./rules/no-temporary-table.js";
 import noTimeType from "./rules/no-time-type.js";
@@ -68,6 +69,7 @@ const rules = {
   "no-select-into": noSelectInto,
   "no-select-star": noSelectStar,
   "no-set-not-null": noSetNotNull,
+  "no-set-search-path": noSetSearchPath,
   "no-syntax-error": noSyntaxError,
   "no-temporary-table": noTemporaryTable,
   "no-time-type": noTimeType,
@@ -132,6 +134,7 @@ plugin.configs = {
       "postgresql/no-rename-table": "warn",
       "postgresql/no-select-into": "warn",
       "postgresql/no-set-not-null": "warn",
+      "postgresql/no-set-search-path": "warn",
       "postgresql/no-syntax-error": "error",
       "postgresql/no-temporary-table": "warn",
       "postgresql/no-time-type": "warn",

--- a/src/rules/no-set-search-path.ts
+++ b/src/rules/no-set-search-path.ts
@@ -1,0 +1,37 @@
+import type { Rule } from "eslint";
+
+interface VariableSetStmt {
+  type: "VariableSetStmt";
+  name?: string;
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `SET search_path = ...` in versioned SQL; qualify identifiers with their schema instead",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noSetSearchPath:
+        "`SET search_path` makes name resolution depend on session state and is a known foot-gun for security-definer functions and CREATE statements. Qualify identifiers with their schema (`audit.events`, `public.users`) instead.",
+    },
+  },
+  create(context) {
+    return {
+      VariableSetStmt(node: VariableSetStmt) {
+        if (node.name !== "search_path") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noSetSearchPath",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-set-search-path/invalid/set-search-path-errors.expected.json
+++ b/tests/fixtures/no-set-search-path/invalid/set-search-path-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noSetSearchPath"
+  }
+]

--- a/tests/fixtures/no-set-search-path/invalid/set-search-path.sql
+++ b/tests/fixtures/no-set-search-path/invalid/set-search-path.sql
@@ -1,0 +1,1 @@
+SET search_path TO audit, public;

--- a/tests/fixtures/no-set-search-path/valid/other-set.sql
+++ b/tests/fixtures/no-set-search-path/valid/other-set.sql
@@ -1,0 +1,1 @@
+SET TIME ZONE 'UTC';

--- a/tests/fixtures/no-set-search-path/valid/qualified.sql
+++ b/tests/fixtures/no-set-search-path/valid/qualified.sql
@@ -1,0 +1,1 @@
+SELECT id FROM audit.events;

--- a/tests/no-set-search-path.test.ts
+++ b/tests/no-set-search-path.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-set-search-path.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-set-search-path", rule, "should disallow SET search_path");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-set-search-path`, a rule that warns on `SET search_path = ...` in versioned SQL. The statement changes name resolution for the rest of the session and is a known security and correctness footgun.

## Motivation

PG's own docs warn about `search_path` injection in SECURITY DEFINER functions, and many production incidents stem from a migration accidentally creating an object in the wrong schema after a `SET search_path` upstream.

## Changes

- New rule `postgresql/no-set-search-path`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-set-search-path.test.ts` covers the flagged form plus a valid schema-qualified SELECT and an unrelated `SET TIME ZONE`.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->