### PR TITLE
feat: add postgresql/require-schema-qualified-table rule

### DIFF
--- a/.changeset/require-schema-qualified-table.md
+++ b/.changeset/require-schema-qualified-table.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/require-schema-qualified-table` rule: warns on `CREATE TABLE foo (...)` without a schema-qualified name. Off by default in `configs.recommended` because many projects keep everything in `public`; enable explicitly when you organize by schema.

--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,28 @@ SET search_path TO audit, public;
 SELECT id FROM audit.events;
 ```
 
+### `postgresql/require-schema-qualified-table`
+
+Warns on `CREATE TABLE foo (...)` without a schema-qualified name. Without an explicit schema, the target depends on the current `search_path` and may land in an unintended schema. This rule is **off** by default in `configs.recommended` because many projects intentionally keep everything in `public`; enable it explicitly for codebases that organize by schema.
+
+**Type**: Suggestion  
+**Recommended**: ❌ Off by default  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE TABLE users (id bigint PRIMARY KEY);
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE app.users (id bigint PRIMARY KEY);
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -673,6 +673,18 @@ export const rules: RuleMeta[] = [
     incorrect: ["SET search_path TO audit, public;"],
     correct: ["SELECT id FROM audit.events;"],
   },
+  {
+    name: "require-schema-qualified-table",
+    description: "Require schema-qualified `CREATE TABLE` (off by default).",
+    longDescription:
+      "`CREATE TABLE foo` resolves through `search_path` and may land in an unintended schema. This rule is off by default in `configs.recommended` because many projects intentionally keep everything in `public`; enable it explicitly when you organize by schema.",
+    type: "suggestion",
+    recommended: "off",
+    fixable: false,
+    category: "schema",
+    incorrect: ["CREATE TABLE users (id bigint PRIMARY KEY);"],
+    correct: ["CREATE TABLE app.users (id bigint PRIMARY KEY);"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import preferTimestamptz from "./rules/prefer-timestamptz.js";
 import requireLimit from "./rules/require-limit.js";
 import requireNamedConstraint from "./rules/require-named-constraint.js";
 import requirePrimaryKey from "./rules/require-primary-key.js";
+import requireSchemaQualifiedTable from "./rules/require-schema-qualified-table.js";
 import requireWhereInDelete from "./rules/require-where-in-delete.js";
 import requireWhereInUpdate from "./rules/require-where-in-update.js";
 import snakeCaseColumnName from "./rules/snake-case-column-name.js";
@@ -85,6 +86,7 @@ const rules = {
   "require-limit": requireLimit,
   "require-named-constraint": requireNamedConstraint,
   "require-primary-key": requirePrimaryKey,
+  "require-schema-qualified-table": requireSchemaQualifiedTable,
   "require-where-in-delete": requireWhereInDelete,
   "require-where-in-update": requireWhereInUpdate,
   "snake-case-column-name": snakeCaseColumnName,

--- a/src/rules/require-schema-qualified-table.ts
+++ b/src/rules/require-schema-qualified-table.ts
@@ -1,0 +1,37 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require `CREATE TABLE` to use a schema-qualified name (e.g. `audit.events`) so the target schema is explicit",
+      category: "Best Practices",
+      recommended: false,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      requireSchemaQualifiedTable:
+        "`CREATE TABLE` should specify a schema (e.g. `audit.events`). Without one, the target depends on `search_path` and may land in an unintended schema. The rule is off by default in `recommended` because many projects intentionally use the `public` schema.",
+    },
+  },
+  create(context) {
+    return {
+      CreateStmt(node: Ast.CreateStmt) {
+        const relation = node.relation as
+          | (Ast.RangeVar & { schemaname?: string })
+          | undefined;
+        if (typeof relation?.schemaname === "string" && relation.schemaname)
+          return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "requireSchemaQualifiedTable",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/require-schema-qualified-table/invalid/unqualified-errors.expected.json
+++ b/tests/fixtures/require-schema-qualified-table/invalid/unqualified-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "requireSchemaQualifiedTable"
+  }
+]

--- a/tests/fixtures/require-schema-qualified-table/invalid/unqualified.sql
+++ b/tests/fixtures/require-schema-qualified-table/invalid/unqualified.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id bigint PRIMARY KEY);

--- a/tests/fixtures/require-schema-qualified-table/valid/qualified.sql
+++ b/tests/fixtures/require-schema-qualified-table/valid/qualified.sql
@@ -1,0 +1,1 @@
+CREATE TABLE app.users (id bigint PRIMARY KEY);

--- a/tests/require-schema-qualified-table.test.ts
+++ b/tests/require-schema-qualified-table.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/require-schema-qualified-table.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "require-schema-qualified-table",
+  rule,
+  "should require schema-qualified CREATE TABLE",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/require-schema-qualified-table`, a rule that warns on `CREATE TABLE foo (...)` without an explicit schema. Off by default in `configs.recommended`; users opt in by enabling the rule.

## Motivation

Multi-schema projects routinely want to enforce explicit schema qualification — but projects that keep everything in `public` would not. Off-by-default lets each project pick.

## Changes

- New rule `postgresql/require-schema-qualified-table`, off by default in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/require-schema-qualified-table.test.ts` covers the flagged unqualified form plus a valid `app.users` case.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change. Because the rule is off by default in `configs.recommended`, users who upgrade do not get new diagnostics unless they enable it.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->