### PR TITLE
feat: add postgresql/prefer-explicit-null-ordering rule

### DIFF
--- a/.changeset/prefer-explicit-null-ordering.md
+++ b/.changeset/prefer-explicit-null-ordering.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-explicit-null-ordering` rule: warns when an `ORDER BY` term specifies an explicit `ASC`/`DESC` direction but no `NULLS FIRST` / `NULLS LAST`. Plain `ORDER BY x` (no direction) is left alone. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,30 @@ CREATE TABLE users (id bigint PRIMARY KEY);
 CREATE TABLE app.users (id bigint PRIMARY KEY);
 ```
 
+### `postgresql/prefer-explicit-null-ordering`
+
+Warns when an `ORDER BY` term specifies an explicit `ASC` / `DESC` / `USING` direction but no `NULLS FIRST` / `NULLS LAST`. PostgreSQL's defaults (NULLS LAST for ASC, NULLS FIRST for DESC) match the SQL spec but contradict every other major engine, and even within PG it is a common cause of surprise when nulls cluster at the "wrong" end of a result set.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+SELECT id FROM users ORDER BY created_at DESC;
+```
+
+✅ Correct:
+
+```sql
+SELECT id FROM users ORDER BY created_at DESC NULLS LAST;
+-- Plain ORDER BY without an explicit direction is not flagged.
+SELECT id FROM users ORDER BY created_at;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -685,6 +685,22 @@ export const rules: RuleMeta[] = [
     incorrect: ["CREATE TABLE users (id bigint PRIMARY KEY);"],
     correct: ["CREATE TABLE app.users (id bigint PRIMARY KEY);"],
   },
+  {
+    name: "prefer-explicit-null-ordering",
+    description:
+      "Require `NULLS FIRST/LAST` when an explicit ORDER BY direction is used.",
+    longDescription:
+      "PostgreSQL's null-ordering defaults (NULLS LAST for ASC, NULLS FIRST for DESC) match the SQL spec but contradict every other major engine. Adding explicit `NULLS FIRST/LAST` removes the surprise and survives copy-paste into other databases.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "style",
+    incorrect: ["SELECT id FROM users ORDER BY created_at DESC;"],
+    correct: [
+      "SELECT id FROM users ORDER BY created_at DESC NULLS LAST;",
+      "SELECT id FROM users ORDER BY created_at;",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import noUnloggedTable from "./rules/no-unlogged-table.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
 import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
+import preferExplicitNullOrdering from "./rules/prefer-explicit-null-ordering.js";
 import preferFkNotValid from "./rules/prefer-fk-not-valid.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
@@ -78,6 +79,7 @@ const rules = {
   "no-unlogged-table": noUnloggedTable,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
   "prefer-create-index-concurrently": preferCreateIndexConcurrently,
+  "prefer-explicit-null-ordering": preferExplicitNullOrdering,
   "prefer-fk-not-valid": preferFkNotValid,
   "prefer-identity-over-serial": preferIdentityOverSerial,
   "prefer-jsonb-over-json": preferJsonbOverJson,
@@ -143,6 +145,7 @@ plugin.configs = {
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/no-unlogged-table": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",
+      "postgresql/prefer-explicit-null-ordering": "warn",
       "postgresql/prefer-fk-not-valid": "warn",
       "postgresql/prefer-identity-over-serial": "warn",
       "postgresql/prefer-jsonb-over-json": "warn",

--- a/src/rules/prefer-explicit-null-ordering.ts
+++ b/src/rules/prefer-explicit-null-ordering.ts
@@ -1,0 +1,42 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "When `ORDER BY` specifies an explicit direction, require an explicit `NULLS FIRST` / `NULLS LAST` so null ordering is not implicit",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferExplicitNullOrdering:
+        "`ORDER BY ... ASC|DESC` without `NULLS FIRST` / `NULLS LAST` relies on PostgreSQL's implicit ordering (NULLS LAST for ASC, NULLS FIRST for DESC), which trips up cross-database readers. Add an explicit `NULLS FIRST` / `NULLS LAST`.",
+    },
+  },
+  create(context) {
+    return {
+      SortBy(node: Ast.SortBy) {
+        // Only flag when the user already specified a direction. Plain
+        // `ORDER BY x` is left alone; this rule is about making *explicit*
+        // ASC/DESC orderings fully unambiguous.
+        if (
+          node.sortby_dir !== "SORTBY_ASC" &&
+          node.sortby_dir !== "SORTBY_DESC" &&
+          node.sortby_dir !== "SORTBY_USING"
+        )
+          return;
+        if (node.sortby_nulls !== "SORTBY_NULLS_DEFAULT") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "preferExplicitNullOrdering",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-explicit-null-ordering/invalid/desc-errors.expected.json
+++ b/tests/fixtures/prefer-explicit-null-ordering/invalid/desc-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferExplicitNullOrdering"
+  }
+]

--- a/tests/fixtures/prefer-explicit-null-ordering/invalid/desc.sql
+++ b/tests/fixtures/prefer-explicit-null-ordering/invalid/desc.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users ORDER BY created_at DESC;

--- a/tests/fixtures/prefer-explicit-null-ordering/valid/no-direction.sql
+++ b/tests/fixtures/prefer-explicit-null-ordering/valid/no-direction.sql
@@ -1,0 +1,2 @@
+-- No explicit ASC/DESC: rule does not fire.
+SELECT id FROM users ORDER BY created_at;

--- a/tests/fixtures/prefer-explicit-null-ordering/valid/with-nulls-last.sql
+++ b/tests/fixtures/prefer-explicit-null-ordering/valid/with-nulls-last.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users ORDER BY created_at DESC NULLS LAST;

--- a/tests/prefer-explicit-null-ordering.test.ts
+++ b/tests/prefer-explicit-null-ordering.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-explicit-null-ordering.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-explicit-null-ordering",
+  rule,
+  "should require NULLS FIRST/LAST when an explicit ORDER BY direction is given",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/prefer-explicit-null-ordering`, a rule that requires `NULLS FIRST` / `NULLS LAST` whenever an explicit `ASC`/`DESC` direction is given. PG's defaults differ from every other major engine and routinely surprise developers.

## Motivation

Cross-database surprise: NULLS LAST for ASC and NULLS FIRST for DESC matches the SQL spec but contradicts MySQL/SQLite/SQL Server. Making the ordering explicit avoids subtle bugs around result tail behavior.

## Changes

- New rule `postgresql/prefer-explicit-null-ordering`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/prefer-explicit-null-ordering.test.ts` covers `ORDER BY ... DESC` (flagged), `... DESC NULLS LAST` (valid), and plain `ORDER BY x` (left alone).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change: a new rule turned on at `warn`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->