### PR TITLE
feat: add postgresql/no-vacuum-full rule

### DIFF
--- a/.changeset/no-vacuum-full.md
+++ b/.changeset/no-vacuum-full.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-vacuum-full` rule: warns on `VACUUM FULL` because it takes `ACCESS EXCLUSIVE` and rewrites the whole table, making it unavailable for the duration. Plain `VACUUM` is fine. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,29 @@ SELECT id FROM users ORDER BY created_at DESC NULLS LAST;
 SELECT id FROM users ORDER BY created_at;
 ```
 
+### `postgresql/no-vacuum-full`
+
+Warns on `VACUUM FULL`. It takes an `ACCESS EXCLUSIVE` lock and rewrites the entire table, making the table unavailable for the duration. For shrinking a bloated table on a live database, use `pg_repack` or `pg_squeeze`; a plain `VACUUM` (no `FULL`) is fine and does not block readers or writers.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+VACUUM FULL users;
+```
+
+✅ Correct:
+
+```sql
+VACUUM users;
+VACUUM ANALYZE users;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -701,6 +701,19 @@ export const rules: RuleMeta[] = [
       "SELECT id FROM users ORDER BY created_at;",
     ],
   },
+  {
+    name: "no-vacuum-full",
+    description:
+      "Warn on `VACUUM FULL` — takes ACCESS EXCLUSIVE and rewrites the table.",
+    longDescription:
+      "`VACUUM FULL` takes `ACCESS EXCLUSIVE` and rewrites the whole table, making it unavailable for the duration. For shrinking a bloated table on a live database use `pg_repack` or `pg_squeeze`; a plain `VACUUM` is fine.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["VACUUM FULL users;"],
+    correct: ["VACUUM users;", "VACUUM ANALYZE users;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import noTemporaryTable from "./rules/no-temporary-table.js";
 import noTimeType from "./rules/no-time-type.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import noUnloggedTable from "./rules/no-unlogged-table.js";
+import noVacuumFull from "./rules/no-vacuum-full.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
 import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import preferExplicitNullOrdering from "./rules/prefer-explicit-null-ordering.js";
@@ -77,6 +78,7 @@ const rules = {
   "no-time-type": noTimeType,
   "no-truncate-cascade": noTruncateCascade,
   "no-unlogged-table": noUnloggedTable,
+  "no-vacuum-full": noVacuumFull,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
   "prefer-create-index-concurrently": preferCreateIndexConcurrently,
   "prefer-explicit-null-ordering": preferExplicitNullOrdering,
@@ -144,6 +146,7 @@ plugin.configs = {
       "postgresql/no-time-type": "warn",
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/no-unlogged-table": "warn",
+      "postgresql/no-vacuum-full": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",
       "postgresql/prefer-explicit-null-ordering": "warn",
       "postgresql/prefer-fk-not-valid": "warn",

--- a/src/rules/no-vacuum-full.ts
+++ b/src/rules/no-vacuum-full.ts
@@ -1,0 +1,47 @@
+import type { Rule } from "eslint";
+
+interface DefElem {
+  type: "DefElem";
+  defname?: string;
+}
+
+interface VacuumStmt {
+  type: "VacuumStmt";
+  options?: DefElem[];
+}
+
+const hasFullOption = (options: VacuumStmt["options"]): boolean => {
+  if (!Array.isArray(options)) return false;
+  return options.some((o) => o && o.type === "DefElem" && o.defname === "full");
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `VACUUM FULL` because it takes ACCESS EXCLUSIVE and rewrites the entire table",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noVacuumFull:
+        "`VACUUM FULL` takes `ACCESS EXCLUSIVE` and rewrites the whole table; the table is unavailable for the duration. For shrinking a bloated table on a live database, use `pg_repack` or `pg_squeeze`. A plain `VACUUM` (no `FULL`) is fine.",
+    },
+  },
+  create(context) {
+    return {
+      VacuumStmt(node: VacuumStmt) {
+        if (!hasFullOption(node.options)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noVacuumFull",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-vacuum-full/invalid/full-errors.expected.json
+++ b/tests/fixtures/no-vacuum-full/invalid/full-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noVacuumFull"
+  }
+]

--- a/tests/fixtures/no-vacuum-full/invalid/full.sql
+++ b/tests/fixtures/no-vacuum-full/invalid/full.sql
@@ -1,0 +1,1 @@
+VACUUM FULL users;

--- a/tests/fixtures/no-vacuum-full/valid/analyze.sql
+++ b/tests/fixtures/no-vacuum-full/valid/analyze.sql
@@ -1,0 +1,1 @@
+VACUUM ANALYZE users;

--- a/tests/fixtures/no-vacuum-full/valid/plain-vacuum.sql
+++ b/tests/fixtures/no-vacuum-full/valid/plain-vacuum.sql
@@ -1,0 +1,1 @@
+VACUUM users;

--- a/tests/no-vacuum-full.test.ts
+++ b/tests/no-vacuum-full.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-vacuum-full.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-vacuum-full", rule, "should disallow VACUUM FULL");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-vacuum-full`, a rule that warns on `VACUUM FULL`. The operation takes ACCESS EXCLUSIVE and rewrites the table; pg_repack/pg_squeeze are the right tools for an online rewrite.

## Motivation

`VACUUM FULL` shows up surprisingly often in maintenance scripts. On a small table it's harmless; on a 200GB table it's an incident.

## Changes

- New rule `postgresql/no-vacuum-full`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-vacuum-full.test.ts` covers `VACUUM FULL` (flagged) and plain `VACUUM` / `VACUUM ANALYZE` (valid).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->