### PR TITLE
feat: add postgresql/no-cluster rule

### DIFF
--- a/.changeset/no-cluster.md
+++ b/.changeset/no-cluster.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-cluster` rule: warns on the `CLUSTER` statement because it takes `ACCESS EXCLUSIVE`, rewrites the table, and PostgreSQL does not keep rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,29 @@ VACUUM users;
 VACUUM ANALYZE users;
 ```
 
+### `postgresql/no-cluster`
+
+Warns on the `CLUSTER` statement. Like `VACUUM FULL`, it takes `ACCESS EXCLUSIVE` and rewrites the table. PostgreSQL does not keep rows clustered as you continue to write — every subsequent `CLUSTER` must rewrite everything again. Use `pg_repack --order-by` for online clustering, or build the index in the order you actually want to read.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CLUSTER users USING users_pkey;
+```
+
+✅ Correct:
+
+```sql
+VACUUM users;
+-- Or: pg_repack --order-by from outside SQL.
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -714,6 +714,19 @@ export const rules: RuleMeta[] = [
     incorrect: ["VACUUM FULL users;"],
     correct: ["VACUUM users;", "VACUUM ANALYZE users;"],
   },
+  {
+    name: "no-cluster",
+    description:
+      "Warn on `CLUSTER` — ACCESS EXCLUSIVE lock, and PG doesn't maintain the order.",
+    longDescription:
+      "`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the whole table just like `VACUUM FULL`. PostgreSQL does not keep rows clustered as you continue to write, so every subsequent `CLUSTER` must rewrite everything again. Use `pg_repack --order-by` for online clustering.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["CLUSTER users USING users_pkey;"],
+    correct: ["VACUUM users;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { name, version } from "./meta.js";
 import noAddColumnNotNullWithoutDefault from "./rules/no-add-column-not-null-without-default.js";
 import noAlterColumnType from "./rules/no-alter-column-type.js";
 import noCharType from "./rules/no-char-type.js";
+import noCluster from "./rules/no-cluster.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.js";
 import noDropColumn from "./rules/no-drop-column.js";
@@ -52,6 +53,7 @@ const rules = {
   "no-add-column-not-null-without-default": noAddColumnNotNullWithoutDefault,
   "no-alter-column-type": noAlterColumnType,
   "no-char-type": noCharType,
+  "no-cluster": noCluster,
   "no-cross-join": noCrossJoin,
   "no-distinct-on-without-order-by": noDistinctOnWithoutOrderBy,
   "no-drop-column": noDropColumn,
@@ -121,6 +123,7 @@ plugin.configs = {
       "postgresql/no-add-column-not-null-without-default": "error",
       "postgresql/no-alter-column-type": "warn",
       "postgresql/no-char-type": "warn",
+      "postgresql/no-cluster": "warn",
       "postgresql/no-cross-join": "warn",
       "postgresql/no-distinct-on-without-order-by": "error",
       "postgresql/no-drop-column": "warn",

--- a/src/rules/no-cluster.ts
+++ b/src/rules/no-cluster.ts
@@ -1,0 +1,35 @@
+import type { Rule } from "eslint";
+
+interface ClusterStmt {
+  type: "ClusterStmt";
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow the `CLUSTER` statement: it takes ACCESS EXCLUSIVE, rewrites the table, and is not maintained afterwards",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCluster:
+        "`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read.",
+    },
+  },
+  create(context) {
+    return {
+      ClusterStmt(node: ClusterStmt) {
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noCluster",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-cluster/invalid/cluster-errors.expected.json
+++ b/tests/fixtures/no-cluster/invalid/cluster-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noCluster"
+  }
+]

--- a/tests/fixtures/no-cluster/invalid/cluster.sql
+++ b/tests/fixtures/no-cluster/invalid/cluster.sql
@@ -1,0 +1,1 @@
+CLUSTER users USING users_pkey;

--- a/tests/fixtures/no-cluster/valid/vacuum.sql
+++ b/tests/fixtures/no-cluster/valid/vacuum.sql
@@ -1,0 +1,1 @@
+VACUUM users;

--- a/tests/no-cluster.test.ts
+++ b/tests/no-cluster.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-cluster.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-cluster", rule, "should disallow CLUSTER");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-cluster`, a rule that warns on the `CLUSTER` statement. Same locking profile as `VACUUM FULL`, with the added downside that PG does not maintain the clustering as you continue to write.

## Motivation

Companion to `no-vacuum-full`. `CLUSTER` shows up in legacy maintenance jobs but offers no online alternative inside core PG.

## Changes

- New rule `postgresql/no-cluster`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-cluster.test.ts` covers `CLUSTER ... USING ...` (flagged) and `VACUUM` (valid).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->