### PR TITLE
feat: add postgresql/no-drop-database rule

### DIFF
--- a/.changeset/no-drop-database.md
+++ b/.changeset/no-drop-database.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-drop-database` rule: errors on `DROP DATABASE`, which is catastrophic and irreversible and should not live in versioned SQL applied unattended by a migration tool. Enabled at `error` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1168,6 +1168,29 @@ VACUUM users;
 -- Or: pg_repack --order-by from outside SQL.
 ```
 
+### `postgresql/no-drop-database`
+
+Errors on `DROP DATABASE`. The operation is catastrophic and irreversible, and database creation/deletion belongs in an explicit operator workflow — not in versioned SQL that runs unattended through a migration tool.
+
+**Type**: Problem  
+**Recommended**: ✅ Error  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+DROP DATABASE archive_2023;
+```
+
+✅ Correct:
+
+```sql
+-- Run DROP DATABASE manually from an operator console, with explicit confirmation.
+DROP TABLE archive;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -727,6 +727,19 @@ export const rules: RuleMeta[] = [
     incorrect: ["CLUSTER users USING users_pkey;"],
     correct: ["VACUUM users;"],
   },
+  {
+    name: "no-drop-database",
+    description:
+      "Error on `DROP DATABASE` — catastrophic and belongs to an operator workflow.",
+    longDescription:
+      "Database creation/deletion is not a normal migration step. The operation is catastrophic and irreversible; require it to be run from an operator console with explicit confirmation, not from versioned SQL.",
+    type: "problem",
+    recommended: "error",
+    fixable: false,
+    category: "safety",
+    incorrect: ["DROP DATABASE archive_2023;"],
+    correct: ["DROP TABLE archive;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import noCluster from "./rules/no-cluster.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.js";
 import noDropColumn from "./rules/no-drop-column.js";
+import noDropDatabase from "./rules/no-drop-database.js";
 import noDropNotNull from "./rules/no-drop-not-null.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
@@ -57,6 +58,7 @@ const rules = {
   "no-cross-join": noCrossJoin,
   "no-distinct-on-without-order-by": noDistinctOnWithoutOrderBy,
   "no-drop-column": noDropColumn,
+  "no-drop-database": noDropDatabase,
   "no-drop-not-null": noDropNotNull,
   "no-drop-table-cascade": noDropTableCascade,
   "no-grant-to-public": noGrantToPublic,
@@ -127,6 +129,7 @@ plugin.configs = {
       "postgresql/no-cross-join": "warn",
       "postgresql/no-distinct-on-without-order-by": "error",
       "postgresql/no-drop-column": "warn",
+      "postgresql/no-drop-database": "error",
       "postgresql/no-drop-not-null": "warn",
       "postgresql/no-drop-table-cascade": "warn",
       "postgresql/no-grant-to-public": "warn",

--- a/src/rules/no-drop-database.ts
+++ b/src/rules/no-drop-database.ts
@@ -1,0 +1,35 @@
+import type { Rule } from "eslint";
+
+interface DropdbStmt {
+  type: "DropdbStmt";
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `DROP DATABASE`; it is catastrophic if run by accident and should not live in versioned SQL",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDropDatabase:
+        "`DROP DATABASE` is catastrophic and irreversible. Database creation/deletion belongs in an explicit operator workflow, not in versioned SQL applied automatically by a migration tool.",
+    },
+  },
+  create(context) {
+    return {
+      DropdbStmt(node: DropdbStmt) {
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noDropDatabase",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-drop-database/invalid/drop-database-errors.expected.json
+++ b/tests/fixtures/no-drop-database/invalid/drop-database-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noDropDatabase"
+  }
+]

--- a/tests/fixtures/no-drop-database/invalid/drop-database.sql
+++ b/tests/fixtures/no-drop-database/invalid/drop-database.sql
@@ -1,0 +1,1 @@
+DROP DATABASE archive_2023;

--- a/tests/fixtures/no-drop-database/valid/drop-table.sql
+++ b/tests/fixtures/no-drop-database/valid/drop-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE archive;

--- a/tests/no-drop-database.test.ts
+++ b/tests/no-drop-database.test.ts
@@ -1,0 +1,4 @@
+import rule from "../src/rules/no-drop-database.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest("no-drop-database", rule, "should disallow DROP DATABASE");


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-drop-database`, a rule that errors on `DROP DATABASE`. The operation is catastrophic and shouldn't run unattended through a migration tool.

## Motivation

Some migration scripts accidentally include teardown statements meant for test fixtures. Erroring at lint time makes that mistake impossible to deploy.

## Changes

- New rule `postgresql/no-drop-database`, enabled at `error` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-drop-database.test.ts` covers `DROP DATABASE` (flagged) and `DROP TABLE` (valid).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->