### PR TITLE
feat: add postgresql/no-drop-schema-cascade rule

### DIFF
--- a/.changeset/no-drop-schema-cascade.md
+++ b/.changeset/no-drop-schema-cascade.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-drop-schema-cascade` rule: warns on `DROP SCHEMA ... CASCADE`, which silently removes every object in the schema. The companion to `no-drop-table-cascade` with a much larger blast radius. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,29 @@ DROP DATABASE archive_2023;
 DROP TABLE archive;
 ```
 
+### `postgresql/no-drop-schema-cascade`
+
+Warns on `DROP SCHEMA ... CASCADE`. The cascade silently removes every table, view, function, and sequence in the schema with no preview — the same anti-pattern as `DROP TABLE CASCADE`, but with a much larger blast radius. Either list the objects you actually want to drop, or drop the schema only when it is already empty.
+
+**Type**: Problem  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+DROP SCHEMA staging CASCADE;
+```
+
+✅ Correct:
+
+```sql
+DROP SCHEMA staging;
+DROP SCHEMA staging RESTRICT;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -740,6 +740,19 @@ export const rules: RuleMeta[] = [
     incorrect: ["DROP DATABASE archive_2023;"],
     correct: ["DROP TABLE archive;"],
   },
+  {
+    name: "no-drop-schema-cascade",
+    description:
+      "Warn on `DROP SCHEMA ... CASCADE` — removes every object in the schema with no preview.",
+    longDescription:
+      "Same anti-pattern as `DROP TABLE CASCADE` but with a much larger blast radius. Either list the objects you actually want to drop, or drop the schema only when it is already empty.",
+    type: "problem",
+    recommended: "warn",
+    fixable: false,
+    category: "safety",
+    incorrect: ["DROP SCHEMA staging CASCADE;"],
+    correct: ["DROP SCHEMA staging;", "DROP SCHEMA staging RESTRICT;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.
 import noDropColumn from "./rules/no-drop-column.js";
 import noDropDatabase from "./rules/no-drop-database.js";
 import noDropNotNull from "./rules/no-drop-not-null.js";
+import noDropSchemaCascade from "./rules/no-drop-schema-cascade.js";
 import noDropTableCascade from "./rules/no-drop-table-cascade.js";
 import noGrantToPublic from "./rules/no-grant-to-public.js";
 import noGroupByOrdinal from "./rules/no-group-by-ordinal.js";
@@ -60,6 +61,7 @@ const rules = {
   "no-drop-column": noDropColumn,
   "no-drop-database": noDropDatabase,
   "no-drop-not-null": noDropNotNull,
+  "no-drop-schema-cascade": noDropSchemaCascade,
   "no-drop-table-cascade": noDropTableCascade,
   "no-grant-to-public": noGrantToPublic,
   "no-group-by-ordinal": noGroupByOrdinal,
@@ -131,6 +133,7 @@ plugin.configs = {
       "postgresql/no-drop-column": "warn",
       "postgresql/no-drop-database": "error",
       "postgresql/no-drop-not-null": "warn",
+      "postgresql/no-drop-schema-cascade": "warn",
       "postgresql/no-drop-table-cascade": "warn",
       "postgresql/no-grant-to-public": "warn",
       "postgresql/no-group-by-ordinal": "warn",

--- a/src/rules/no-drop-schema-cascade.ts
+++ b/src/rules/no-drop-schema-cascade.ts
@@ -1,0 +1,34 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `DROP SCHEMA ... CASCADE`; it silently removes every object in the schema",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noDropSchemaCascade:
+        "`DROP SCHEMA ... CASCADE` removes every table, view, function, and sequence in the schema with no preview. List the objects you actually want to drop instead, or drop the schema only when it's already empty.",
+    },
+  },
+  create(context) {
+    return {
+      DropStmt(node: Ast.DropStmt) {
+        if (node.removeType !== "OBJECT_SCHEMA") return;
+        if (node.behavior !== "DROP_CASCADE") return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noDropSchemaCascade",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-drop-schema-cascade/invalid/cascade-errors.expected.json
+++ b/tests/fixtures/no-drop-schema-cascade/invalid/cascade-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noDropSchemaCascade"
+  }
+]

--- a/tests/fixtures/no-drop-schema-cascade/invalid/cascade.sql
+++ b/tests/fixtures/no-drop-schema-cascade/invalid/cascade.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA staging CASCADE;

--- a/tests/fixtures/no-drop-schema-cascade/valid/plain.sql
+++ b/tests/fixtures/no-drop-schema-cascade/valid/plain.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA staging;

--- a/tests/fixtures/no-drop-schema-cascade/valid/restrict.sql
+++ b/tests/fixtures/no-drop-schema-cascade/valid/restrict.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA staging RESTRICT;

--- a/tests/no-drop-schema-cascade.test.ts
+++ b/tests/no-drop-schema-cascade.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-drop-schema-cascade.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-drop-schema-cascade",
+  rule,
+  "should disallow DROP SCHEMA ... CASCADE",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-drop-schema-cascade`, a rule that warns on `DROP SCHEMA ... CASCADE`. Companion to the existing `no-drop-table-cascade`, with a much larger blast radius.

## Motivation

`DROP SCHEMA staging CASCADE` is sometimes copy-pasted from teardown scripts into the wrong file. Catching at lint time prevents a particularly bad outage.

## Changes

- New rule `postgresql/no-drop-schema-cascade`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-drop-schema-cascade.test.ts` covers CASCADE (flagged), RESTRICT (valid), and bare `DROP SCHEMA` (valid).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->