### PR TITLE
feat: add postgresql/no-create-role rule

### DIFF
--- a/.changeset/no-create-role.md
+++ b/.changeset/no-create-role.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/no-create-role` rule: warns on `CREATE ROLE` / `CREATE USER` in versioned SQL. Roles and credentials belong in an operator-managed bootstrap workflow, not in application migrations. Granting privileges to existing roles remains fine. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1236,6 +1236,29 @@ REINDEX TABLE users;
 REINDEX TABLE CONCURRENTLY users;
 ```
 
+### `postgresql/no-create-role`
+
+Warns on `CREATE ROLE` / `CREATE USER` in versioned SQL. Roles and credentials belong in an operator-managed bootstrap (Terraform, Pulumi, a runbook with explicit approvals), not in application migrations that run automatically with whichever role the deploy uses. Granting privileges to existing roles is fine.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE ROLE app_writer LOGIN PASSWORD 'redacted';
+```
+
+✅ Correct:
+
+```sql
+-- Manage roles in a separate bootstrap workflow; grant privileges from migrations.
+GRANT SELECT ON users TO app_reader;
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -766,6 +766,18 @@ export const rules: RuleMeta[] = [
     incorrect: ["REINDEX TABLE users;"],
     correct: ["REINDEX TABLE CONCURRENTLY users;"],
   },
+  {
+    name: "no-create-role",
+    description: "Disallow `CREATE ROLE` / `CREATE USER` in versioned SQL.",
+    longDescription:
+      "Roles and credentials belong in an operator-managed bootstrap, not in application migrations that run automatically. Granting privileges to existing roles from a migration is fine.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "security",
+    incorrect: ["CREATE ROLE app_writer LOGIN PASSWORD 'redacted';"],
+    correct: ["GRANT SELECT ON users TO app_reader;"],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import noAddColumnNotNullWithoutDefault from "./rules/no-add-column-not-null-wit
 import noAlterColumnType from "./rules/no-alter-column-type.js";
 import noCharType from "./rules/no-char-type.js";
 import noCluster from "./rules/no-cluster.js";
+import noCreateRole from "./rules/no-create-role.js";
 import noCrossJoin from "./rules/no-cross-join.js";
 import noDistinctOnWithoutOrderBy from "./rules/no-distinct-on-without-order-by.js";
 import noDropColumn from "./rules/no-drop-column.js";
@@ -57,6 +58,7 @@ const rules = {
   "no-alter-column-type": noAlterColumnType,
   "no-char-type": noCharType,
   "no-cluster": noCluster,
+  "no-create-role": noCreateRole,
   "no-cross-join": noCrossJoin,
   "no-distinct-on-without-order-by": noDistinctOnWithoutOrderBy,
   "no-drop-column": noDropColumn,
@@ -130,6 +132,7 @@ plugin.configs = {
       "postgresql/no-alter-column-type": "warn",
       "postgresql/no-char-type": "warn",
       "postgresql/no-cluster": "warn",
+      "postgresql/no-create-role": "warn",
       "postgresql/no-cross-join": "warn",
       "postgresql/no-distinct-on-without-order-by": "error",
       "postgresql/no-drop-column": "warn",

--- a/src/rules/no-create-role.ts
+++ b/src/rules/no-create-role.ts
@@ -1,0 +1,35 @@
+import type { Rule } from "eslint";
+
+interface CreateRoleStmt {
+  type: "CreateRoleStmt";
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow `CREATE ROLE` / `CREATE USER` in application migrations; manage roles in a separate operator workflow",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noCreateRole:
+        "`CREATE ROLE` / `CREATE USER` belongs in an operator-managed bootstrap (Terraform, Pulumi, a runbook), not in application migrations. Migration files run with whichever role the deploy uses and are not the right place to manage permissions.",
+    },
+  },
+  create(context) {
+    return {
+      CreateRoleStmt(node: CreateRoleStmt) {
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "noCreateRole",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/no-create-role/invalid/create-role-errors.expected.json
+++ b/tests/fixtures/no-create-role/invalid/create-role-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "noCreateRole"
+  }
+]

--- a/tests/fixtures/no-create-role/invalid/create-role.sql
+++ b/tests/fixtures/no-create-role/invalid/create-role.sql
@@ -1,0 +1,1 @@
+CREATE ROLE app_writer LOGIN PASSWORD 'redacted';

--- a/tests/fixtures/no-create-role/valid/grant.sql
+++ b/tests/fixtures/no-create-role/valid/grant.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON users TO app_reader;

--- a/tests/no-create-role.test.ts
+++ b/tests/no-create-role.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/no-create-role.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "no-create-role",
+  rule,
+  "should disallow CREATE ROLE / CREATE USER",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/no-create-role`, a rule that warns on `CREATE ROLE` / `CREATE USER` in versioned SQL. Roles and credentials belong in an operator-managed bootstrap, not in application migrations.

## Motivation

Migration tools run with whichever role the deploy uses; creating a role from there means whoever runs the migration is implicitly granting credentials, often without review. Granting privileges to existing roles remains fine and is unaffected.

## Changes

- New rule `postgresql/no-create-role`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/no-create-role.test.ts` covers `CREATE ROLE` (flagged) and `GRANT` (valid).
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->