### PR TITLE
feat: add postgresql/prefer-bigint-id rule

### DIFF
--- a/.changeset/prefer-bigint-id.md
+++ b/.changeset/prefer-bigint-id.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/prefer-bigint-id` rule: warns when a primary-key `id` column is declared as `int`, `smallint`, `serial`, or `smallserial`. Widening an integer primary key later requires a full table rewrite under `ACCESS EXCLUSIVE`; declaring `bigint` from the start avoids that future incident. UUID primary keys and non-PK `id` columns are unaffected. Enabled at `warn` severity in `configs.recommended`.

--- a/README.md
+++ b/README.md
@@ -1259,6 +1259,33 @@ CREATE ROLE app_writer LOGIN PASSWORD 'redacted';
 GRANT SELECT ON users TO app_reader;
 ```
 
+### `postgresql/prefer-bigint-id`
+
+Warns when an `id` column declared as a primary key uses `int`, `smallint`, `serial`, or `smallserial`. `int` primary keys overflow at 2.1 billion rows — a soft cap that tables with even moderate write traffic eventually hit. Widening the type later requires a table rewrite under `ACCESS EXCLUSIVE`. Declare the primary key as `bigint GENERATED ALWAYS AS IDENTITY` from the start. UUID primary keys are unaffected.
+
+**Type**: Suggestion  
+**Recommended**: ⚠️ Warn  
+**Fixable**: ❌ No
+
+#### Examples
+
+❌ Incorrect:
+
+```sql
+CREATE TABLE users (id int PRIMARY KEY, name text);
+CREATE TABLE users (id serial PRIMARY KEY, name text);
+CREATE TABLE users (id int, name text, PRIMARY KEY (id));
+```
+
+✅ Correct:
+
+```sql
+CREATE TABLE users (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name text);
+CREATE TABLE users (id uuid PRIMARY KEY, name text);
+-- An int `id` column that is NOT a primary key is also fine.
+CREATE TABLE event_count (id int, count int);
+```
+
 ## Configuration Examples
 
 ### Project Usage Example

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -778,6 +778,26 @@ export const rules: RuleMeta[] = [
     incorrect: ["CREATE ROLE app_writer LOGIN PASSWORD 'redacted';"],
     correct: ["GRANT SELECT ON users TO app_reader;"],
   },
+  {
+    name: "prefer-bigint-id",
+    description:
+      "Prefer `bigint` for primary-key `id` columns; `int` overflows at 2.1B rows.",
+    longDescription:
+      "An `int` primary key overflows at ~2.1 billion rows. Widening the type later requires a table rewrite under `ACCESS EXCLUSIVE`. Declare the primary key as `bigint GENERATED ALWAYS AS IDENTITY` from the start. UUID primary keys and non-PK `id` columns are not flagged.",
+    type: "suggestion",
+    recommended: "warn",
+    fixable: false,
+    category: "schema",
+    incorrect: [
+      "CREATE TABLE users (id int PRIMARY KEY, name text);",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text);",
+      "CREATE TABLE users (id int, name text, PRIMARY KEY (id));",
+    ],
+    correct: [
+      "CREATE TABLE users (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name text);",
+      "CREATE TABLE users (id uuid PRIMARY KEY, name text);",
+    ],
+  },
 ];
 
 export const ruleByName = new Map(rules.map((r) => [r.name, r]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import noTimeType from "./rules/no-time-type.js";
 import noTruncateCascade from "./rules/no-truncate-cascade.js";
 import noUnloggedTable from "./rules/no-unlogged-table.js";
 import noVacuumFull from "./rules/no-vacuum-full.js";
+import preferBigintId from "./rules/prefer-bigint-id.js";
 import preferCoalesceOverCase from "./rules/prefer-coalesce-over-case.js";
 import preferCreateIndexConcurrently from "./rules/prefer-create-index-concurrently.js";
 import preferExplicitNullOrdering from "./rules/prefer-explicit-null-ordering.js";
@@ -88,6 +89,7 @@ const rules = {
   "no-truncate-cascade": noTruncateCascade,
   "no-unlogged-table": noUnloggedTable,
   "no-vacuum-full": noVacuumFull,
+  "prefer-bigint-id": preferBigintId,
   "prefer-coalesce-over-case": preferCoalesceOverCase,
   "prefer-create-index-concurrently": preferCreateIndexConcurrently,
   "prefer-explicit-null-ordering": preferExplicitNullOrdering,
@@ -161,6 +163,7 @@ plugin.configs = {
       "postgresql/no-truncate-cascade": "warn",
       "postgresql/no-unlogged-table": "warn",
       "postgresql/no-vacuum-full": "warn",
+      "postgresql/prefer-bigint-id": "warn",
       "postgresql/prefer-coalesce-over-case": "warn",
       "postgresql/prefer-explicit-null-ordering": "warn",
       "postgresql/prefer-fk-not-valid": "warn",

--- a/src/rules/prefer-bigint-id.ts
+++ b/src/rules/prefer-bigint-id.ts
@@ -1,0 +1,80 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { getTypeName, isColumnDef, isConstraint } from "../utils/ast.js";
+
+const SMALL_INT_TYPES = new Set<string>([
+  // pg_catalog-qualified canonical names
+  "int2", // SMALLINT
+  "int4", // INT / INTEGER
+  // The pseudo-types pg uses when SERIAL is rewritten
+  "smallserial",
+  "serial",
+]);
+
+const isPrimaryKey = (col: Ast.ColumnDef): boolean => {
+  const constraints = col.constraints;
+  if (!Array.isArray(constraints)) return false;
+  return constraints.some(
+    (c) => isConstraint(c) && c.contype === "CONSTR_PRIMARY",
+  );
+};
+
+const isTablePrimaryKeyOn = (
+  elts: Ast.CreateStmt["tableElts"],
+  colname: string,
+): boolean => {
+  if (!Array.isArray(elts)) return false;
+  return elts.some((elt) => {
+    if (!isConstraint(elt)) return false;
+    if (elt.contype !== "CONSTR_PRIMARY") return false;
+    const keys = (elt as Ast.Constraint & { keys?: unknown }).keys;
+    if (!Array.isArray(keys)) return false;
+    return keys.some(
+      (k) =>
+        typeof k === "object" &&
+        k !== null &&
+        (k as { sval?: unknown }).sval === colname,
+    );
+  });
+};
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer `bigint` for primary-key `id` columns; `int` / `smallint` primary keys risk silent overflow on growing tables",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      preferBigintId:
+        "Primary-key `id` columns should be `bigint`. `int` overflows at 2.1 billion rows and the migration to widen it later requires a table rewrite under `ACCESS EXCLUSIVE`. Declare the column as `bigint GENERATED ALWAYS AS IDENTITY` from the start.",
+    },
+  },
+  create(context) {
+    return {
+      CreateStmt(node: Ast.CreateStmt) {
+        const elts = node.tableElts;
+        if (!Array.isArray(elts)) return;
+        for (const elt of elts) {
+          if (!isColumnDef(elt)) continue;
+          if (elt.colname !== "id") continue;
+          const t = getTypeName(elt.typeName);
+          if (typeof t !== "string") continue;
+          if (!SMALL_INT_TYPES.has(t)) continue;
+          if (!isPrimaryKey(elt) && !isTablePrimaryKeyOn(elts, elt.colname))
+            continue;
+          context.report({
+            node: elt as unknown as Rule.Node,
+            messageId: "preferBigintId",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-bigint-id/invalid/int-pk-errors.expected.json
+++ b/tests/fixtures/prefer-bigint-id/invalid/int-pk-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferBigintId"
+  }
+]

--- a/tests/fixtures/prefer-bigint-id/invalid/int-pk.sql
+++ b/tests/fixtures/prefer-bigint-id/invalid/int-pk.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id int PRIMARY KEY, name text);

--- a/tests/fixtures/prefer-bigint-id/invalid/serial-pk-errors.expected.json
+++ b/tests/fixtures/prefer-bigint-id/invalid/serial-pk-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferBigintId"
+  }
+]

--- a/tests/fixtures/prefer-bigint-id/invalid/serial-pk.sql
+++ b/tests/fixtures/prefer-bigint-id/invalid/serial-pk.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id serial PRIMARY KEY, name text);

--- a/tests/fixtures/prefer-bigint-id/invalid/table-pk-errors.expected.json
+++ b/tests/fixtures/prefer-bigint-id/invalid/table-pk-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "preferBigintId"
+  }
+]

--- a/tests/fixtures/prefer-bigint-id/invalid/table-pk.sql
+++ b/tests/fixtures/prefer-bigint-id/invalid/table-pk.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id int, name text, PRIMARY KEY (id));

--- a/tests/fixtures/prefer-bigint-id/valid/bigint-pk.sql
+++ b/tests/fixtures/prefer-bigint-id/valid/bigint-pk.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name text);

--- a/tests/fixtures/prefer-bigint-id/valid/int-not-pk.sql
+++ b/tests/fixtures/prefer-bigint-id/valid/int-not-pk.sql
@@ -1,0 +1,2 @@
+-- An int `id` column that is not a primary key is not flagged.
+CREATE TABLE event_count (id int, count int);

--- a/tests/fixtures/prefer-bigint-id/valid/uuid-pk.sql
+++ b/tests/fixtures/prefer-bigint-id/valid/uuid-pk.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id uuid PRIMARY KEY, name text);

--- a/tests/prefer-bigint-id.test.ts
+++ b/tests/prefer-bigint-id.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-bigint-id.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-bigint-id",
+  rule,
+  "should prefer bigint for primary-key id columns",
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/prefer-bigint-id`, a rule that warns when an `id` column declared as a primary key uses `int`, `smallint`, `serial`, or `smallserial`. UUID primary keys and non-PK `id` columns are not flagged.

## Motivation

Integer-PK overflow is one of those design choices that's free at design time and expensive forever afterwards. The classic Discord / Notion / Sentry blog posts document the migration pain. `bigint` from the start sidesteps it entirely.

## Changes

- New rule `postgresql/prefer-bigint-id`, enabled at `warn` in `configs.recommended`.
- README rules section + site/rules.ts catalog entry.
- Changeset (minor bump).

## Testing

- `pnpm test tests/prefer-bigint-id.test.ts` covers `int PRIMARY KEY`, `serial PRIMARY KEY`, table-level `PRIMARY KEY (id)`, plus valid cases for `bigint GENERATED ... IDENTITY`, `uuid` PK, and an `int` non-PK column.
- `pnpm check:all && pnpm test` clean locally.

## Breaking changes

None. Additive change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->