### PR TITLE
feat: add configs.stylistic preset and prefer-keyword-case rule

### DIFF
--- a/.changeset/stylistic-preset-and-prefer-keyword-case.md
+++ b/.changeset/stylistic-preset-and-prefer-keyword-case.md
@@ -1,0 +1,12 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `configs.stylistic` preset and the first rule in it,
+`postgresql/prefer-keyword-case`. The new preset is opt-in and groups
+auto-fixable layout / casing rules; PostgreSQL formatters do not cover
+PL/pgSQL well, so this plugin will host a stylistic layer of its own.
+
+`prefer-keyword-case` enforces consistent casing for SQL keywords. The
+default is `upper`; pass `["error", { case: "lower" }]` to flip it. Auto-
+fixable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,14 @@ For a lint plugin, this translates concretely:
 
 - **One rule per concern.** Don't add `no-foo` and `prefer-not-foo` when one
   rule with an option covers it.
-- **`configs.recommended` is the canonical preset.** Don't add `configs.strict`
-  / `configs.loose` / `configs.all` just to expose different severity sets —
-  users can flip severities per rule themselves.
+- **`configs.recommended` is the canonical preset for correctness.** Don't add
+  `configs.strict` / `configs.loose` / `configs.all` just to expose different
+  severity sets — users can flip severities per rule themselves.
+- **`configs.stylistic` is the second preset, for layout / casing / formatting
+  rules only.** It exists because PostgreSQL formatters (`prettier-plugin-sql`,
+  `pg_format`) do not cover PL/pgSQL well, and because correctness and style
+  are genuinely orthogonal axes that users opt into independently. Stylistic
+  rules MUST be `fixable`. Do not split it further (no `stylistic-strict` etc).
 - **Options are a last resort.** Each option is a forever-supported branch. If
   you can't name a real user with a real need, don't add the option.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ export default [
 ];
 ```
 
+### Stylistic preset (optional)
+
+Layout / casing / formatting rules live in a separate `configs.stylistic`
+preset. PostgreSQL formatters (`prettier-plugin-sql`, `pg_format`) do not
+cover PL/pgSQL well, so this plugin ships an opt-in stylistic layer. Every
+rule in `configs.stylistic` is auto-fixable.
+
+```js
+import postgresql from "eslint-plugin-postgresql";
+
+export default [
+  {
+    files: ["**/*.sql"],
+    ...postgresql.configs.recommended,
+  },
+  {
+    files: ["**/*.sql"],
+    ...postgresql.configs.stylistic,
+  },
+];
+```
+
 ## Rules
 
 Click a rule name to open its documentation page (examples, rationale, options).
@@ -63,6 +85,7 @@ Click a rule name to open its documentation page (examples, rationale, options).
 
 - ✅ — enabled as `error` in `configs.recommended`
 - ⚠️ — enabled as `warn` in `configs.recommended`
+- 🎨 — enabled in `configs.stylistic` (auto-fixable)
 - (blank) — off by default; opt in per project
 
 | Rule                                                                                                                                           | Description                                                                | Recommended |
@@ -108,6 +131,7 @@ Click a rule name to open its documentation page (examples, rationale, options).
 | [prefer-fk-not-valid](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-fk-not-valid)                                       | Prefer adding foreign keys with `NOT VALID`, then `VALIDATE CONSTRAINT`    |     ⚠️      |
 | [prefer-identity-over-serial](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-identity-over-serial)                       | Prefer `GENERATED ... AS IDENTITY` over `serial` pseudo-types              |     ⚠️      |
 | [prefer-jsonb-over-json](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-jsonb-over-json)                                 | Prefer `jsonb` over `json` columns                                         |     ⚠️      |
+| [prefer-keyword-case](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-keyword-case)                                       | Enforce a consistent case (upper or lower) for SQL keywords                |     🎨      |
 | [prefer-reindex-concurrently](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-reindex-concurrently)                       | Prefer `REINDEX ... CONCURRENTLY`                                          |     ⚠️      |
 | [prefer-text-over-varchar](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-text-over-varchar)                             | Prefer `text` over `varchar(n)`                                            |     ⚠️      |
 | [prefer-timestamptz](https://baseballyama.github.io/eslint-plugin-postgresql/rules/prefer-timestamptz)                                         | Prefer `timestamptz` over `timestamp`                                      |     ⚠️      |

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import preferExplicitNullOrdering from "./rules/prefer-explicit-null-ordering.js
 import preferFkNotValid from "./rules/prefer-fk-not-valid.js";
 import preferIdentityOverSerial from "./rules/prefer-identity-over-serial.js";
 import preferJsonbOverJson from "./rules/prefer-jsonb-over-json.js";
+import preferKeywordCase from "./rules/prefer-keyword-case.js";
 import preferReindexConcurrently from "./rules/prefer-reindex-concurrently.js";
 import preferTextOverVarchar from "./rules/prefer-text-over-varchar.js";
 import preferTimestamptz from "./rules/prefer-timestamptz.js";
@@ -96,6 +97,7 @@ const rules = {
   "prefer-fk-not-valid": preferFkNotValid,
   "prefer-identity-over-serial": preferIdentityOverSerial,
   "prefer-jsonb-over-json": preferJsonbOverJson,
+  "prefer-keyword-case": preferKeywordCase,
   "prefer-reindex-concurrently": preferReindexConcurrently,
   "prefer-text-over-varchar": preferTextOverVarchar,
   "prefer-timestamptz": preferTimestamptz,
@@ -179,6 +181,16 @@ plugin.configs = {
       "postgresql/require-where-in-update": "error",
       "postgresql/snake-case-column-name": "warn",
       "postgresql/snake-case-table-name": "warn",
+    },
+  } satisfies Linter.Config,
+  stylistic: {
+    files: ["**/*.sql"],
+    plugins: { postgresql: plugin },
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: {
+      "postgresql/prefer-keyword-case": "warn",
     },
   } satisfies Linter.Config,
 };

--- a/src/rules/prefer-keyword-case.ts
+++ b/src/rules/prefer-keyword-case.ts
@@ -1,0 +1,59 @@
+import type { Rule } from "eslint";
+
+type CaseStyle = "upper" | "lower";
+
+const DEFAULT_CASE: CaseStyle = "upper";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "layout",
+    docs: {
+      description:
+        "Enforce a consistent case (upper or lower) for SQL keywords",
+      category: "Stylistic Issues",
+      recommended: false,
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          case: { enum: ["upper", "lower"] },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      expectedUpper:
+        "SQL keyword '{{actual}}' should be uppercase: '{{expected}}'.",
+      expectedLower:
+        "SQL keyword '{{actual}}' should be lowercase: '{{expected}}'.",
+    },
+  },
+  create(context) {
+    const option = (context.options[0] ?? {}) as { case?: CaseStyle };
+    const target: CaseStyle = option.case ?? DEFAULT_CASE;
+    const expected = target === "upper" ? "expectedUpper" : "expectedLower";
+    const transform = (value: string) =>
+      target === "upper" ? value.toUpperCase() : value.toLowerCase();
+
+    return {
+      Program() {
+        const tokens = context.sourceCode.ast.tokens ?? [];
+        for (const token of tokens) {
+          if (token.type !== "Keyword") continue;
+          const desired = transform(token.value);
+          if (token.value === desired) continue;
+          context.report({
+            loc: token.loc,
+            messageId: expected,
+            data: { actual: token.value, expected: desired },
+            fix: (fixer) => fixer.replaceTextRange(token.range, desired),
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/fixtures/prefer-keyword-case/invalid/lowercase-keywords-errors.expected.json
+++ b/tests/fixtures/prefer-keyword-case/invalid/lowercase-keywords-errors.expected.json
@@ -1,0 +1,7 @@
+[
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" }
+]

--- a/tests/fixtures/prefer-keyword-case/invalid/lowercase-keywords-output.expected.sql
+++ b/tests/fixtures/prefer-keyword-case/invalid/lowercase-keywords-output.expected.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users WHERE active = TRUE LIMIT 10;

--- a/tests/fixtures/prefer-keyword-case/invalid/lowercase-keywords.sql
+++ b/tests/fixtures/prefer-keyword-case/invalid/lowercase-keywords.sql
@@ -1,0 +1,1 @@
+select id, name from users where active = true limit 10;

--- a/tests/fixtures/prefer-keyword-case/invalid/mixed-case-errors.expected.json
+++ b/tests/fixtures/prefer-keyword-case/invalid/mixed-case-errors.expected.json
@@ -1,0 +1,6 @@
+[
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" },
+  { "messageId": "expectedUpper" }
+]

--- a/tests/fixtures/prefer-keyword-case/invalid/mixed-case-output.expected.sql
+++ b/tests/fixtures/prefer-keyword-case/invalid/mixed-case-output.expected.sql
@@ -1,0 +1,1 @@
+SELECT id FROM users WHERE active = TRUE;

--- a/tests/fixtures/prefer-keyword-case/invalid/mixed-case.sql
+++ b/tests/fixtures/prefer-keyword-case/invalid/mixed-case.sql
@@ -1,0 +1,1 @@
+Select id From users Where active = True;

--- a/tests/fixtures/prefer-keyword-case/valid/upper-default.sql
+++ b/tests/fixtures/prefer-keyword-case/valid/upper-default.sql
@@ -1,0 +1,1 @@
+SELECT id, name FROM users WHERE active = TRUE LIMIT 10;

--- a/tests/fixtures/prefer-keyword-case/valid/upper-string-literal.sql
+++ b/tests/fixtures/prefer-keyword-case/valid/upper-string-literal.sql
@@ -1,0 +1,1 @@
+SELECT 'select from where' AS phrase FROM users;

--- a/tests/fixtures/prefer-keyword-case/valid/upper-with-comment.sql
+++ b/tests/fixtures/prefer-keyword-case/valid/upper-with-comment.sql
@@ -1,0 +1,2 @@
+-- the keyword 'select' inside a comment must not be touched
+SELECT id FROM users;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -52,4 +52,35 @@ describe("eslint-plugin-postgresql", () => {
       ).toBeDefined();
     }
   });
+
+  it("ships configs.stylistic that only references fixable rules", () => {
+    const stylistic = plugin.configs?.["stylistic"];
+    expect(stylistic).toBeDefined();
+    if (!stylistic || typeof stylistic !== "object") return;
+
+    const plugins = (stylistic as { plugins?: Record<string, unknown> })
+      .plugins;
+    expect(plugins?.["postgresql"]).toBe(plugin);
+
+    const rules = (stylistic as { rules?: Record<string, unknown> }).rules;
+    expect(rules).toBeDefined();
+    for (const key of Object.keys(rules ?? {})) {
+      expect(key.startsWith("postgresql/"), `${key} missing namespace`).toBe(
+        true,
+      );
+      const ruleName = key.slice("postgresql/".length);
+      const rule = plugin.rules?.[ruleName];
+      expect(
+        rule,
+        `stylistic references unknown rule "${ruleName}"`,
+      ).toBeDefined();
+      // Stylistic rules must be auto-fixable; this is the contract for
+      // anything that lives in this preset.
+      const meta = (rule as { meta?: { fixable?: unknown } }).meta;
+      expect(
+        meta?.fixable,
+        `stylistic rule "${ruleName}" must declare meta.fixable`,
+      ).toBeTruthy();
+    }
+  });
 });

--- a/tests/prefer-keyword-case.test.ts
+++ b/tests/prefer-keyword-case.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/prefer-keyword-case.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "prefer-keyword-case",
+  rule,
+  "Enforce a consistent case (upper or lower) for SQL keywords",
+);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -31,7 +31,9 @@ const readFixtureFiles = (
 // Invalid fixtureを読み込む共通関数
 const readInvalidFixtures = (folderPath: string) => {
   const files = readdirSync(folderPath);
-  const sqlFiles = files.filter((file) => file.endsWith(".sql"));
+  const sqlFiles = files.filter(
+    (file) => file.endsWith(".sql") && !file.endsWith(".expected.sql"),
+  );
 
   return sqlFiles.map((file) => {
     const baseName = file.replace(".sql", "");
@@ -41,10 +43,20 @@ const readInvalidFixtures = (folderPath: string) => {
     const expectedErrors = readFileSync(expectedErrorsPath, "utf-8");
     const errors = JSON.parse(expectedErrors);
 
+    const expectedOutputFile = `${baseName}-output.expected.sql`;
+    const expectedOutputPath = join(folderPath, expectedOutputFile);
+    let output: string | undefined;
+    try {
+      output = readFileSync(expectedOutputPath, "utf-8").trim();
+    } catch {
+      output = undefined;
+    }
+
     return {
       code: readFileSync(join(folderPath, file), "utf-8").trim(),
       filename: file,
       errors,
+      ...(output !== undefined ? { output } : {}),
     };
   });
 };


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Introduces an opt-in `configs.stylistic` preset alongside `configs.recommended`, and ships its first occupant — `prefer-keyword-case`. The new preset is the home for layout / casing / formatting rules, all of which must be auto-fixable.

## Motivation

PostgreSQL formatters such as `prettier-plugin-sql` and `pg_format` do not cover PL/pgSQL well (DO blocks, `CREATE FUNCTION ... LANGUAGE plpgsql`, `DECLARE`/`BEGIN`/`END`, exception handlers). Rather than defer to a formatter that doesn't reach the body of stored procedures, this plugin will host its own stylistic layer — modeled after `eslint-stylistic`. This PR is the foundation for that layer plus a PoC rule that proves the `postgresql-eslint-parser` token API is sufficient for token-level fixers.

## Changes

- New preset `configs.stylistic` (opt-in; users compose alongside `configs.recommended`).
- New rule `postgresql/prefer-keyword-case` with `{ case: "upper" | "lower" }` option (default `"upper"`); auto-fixable.
- `tests/test-utils.ts` now also picks up an optional `<basename>-output.expected.sql` so fixture-driven tests can assert autofix output.
- `tests/index.test.ts` gains a smoke test that enforces the preset contract: every rule referenced from `configs.stylistic` must declare `meta.fixable`.
- `CLAUDE.md` updated to record the second-preset exception and its scope (no further preset splits).
- README documents the new preset and its 🎨 legend marker.

## Testing

- `pnpm test:all` (format, types, lint, vitest, build, publint, knip) — all green
- `tests/prefer-keyword-case.test.ts` covers: keyword in upper / lower / mixed case, keywords inside `--` comments and string literals are left untouched, autofix output verified via `*-output.expected.sql`

```bash
pnpm test:all
```

## Breaking changes

None. `configs.stylistic` is additive and opt-in; `configs.recommended` is unchanged.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->