### PR TITLE
feat: add postgresql/align-column-definitions rule

### DIFF
--- a/.changeset/align-column-definitions.md
+++ b/.changeset/align-column-definitions.md
@@ -1,0 +1,16 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `postgresql/align-column-definitions` (in `configs.stylistic`,
+auto-fixable).
+
+Aligns column definitions inside a `CREATE TABLE` so that name, type,
+and constraints share consistent column offsets across rows. Two-space
+gap between fields, computed from the longest name and longest type in
+the table.
+
+Conservative on purpose: skips tables that mix column definitions with
+table-level constraints, tables that have multi-line column defs, and
+lines that carry inline `--` or `/*` comments. These cases need more
+careful source surgery and are deferred.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Click a rule name to open its documentation page (examples, rationale, options).
 
 | Rule                                                                                                                                           | Description                                                                | Recommended |
 | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | :---------: |
+| [align-column-definitions](https://baseballyama.github.io/eslint-plugin-postgresql/rules/align-column-definitions)                             | Align column definitions vertically inside `CREATE TABLE`                  |     🎨      |
 | [no-add-column-not-null-without-default](https://baseballyama.github.io/eslint-plugin-postgresql/rules/no-add-column-not-null-without-default) | Disallow `ADD COLUMN ... NOT NULL` without a `DEFAULT`                     |     ✅      |
 | [no-alter-column-type](https://baseballyama.github.io/eslint-plugin-postgresql/rules/no-alter-column-type)                                     | Disallow `ALTER COLUMN ... TYPE` (table rewrite under exclusive lock)      |     ⚠️      |
 | [no-char-type](https://baseballyama.github.io/eslint-plugin-postgresql/rules/no-char-type)                                                     | Disallow `char(n)` / `bpchar(n)` columns                                   |     ⚠️      |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { ESLint, Linter } from "eslint";
 import postgresqlParser from "postgresql-eslint-parser";
 import { name, version } from "./meta.js";
+import alignColumnDefinitions from "./rules/align-column-definitions.js";
 import noAddColumnNotNullWithoutDefault from "./rules/no-add-column-not-null-without-default.js";
 import noAlterColumnType from "./rules/no-alter-column-type.js";
 import noCharType from "./rules/no-char-type.js";
@@ -64,6 +65,7 @@ import snakeCaseColumnName from "./rules/snake-case-column-name.js";
 import snakeCaseTableName from "./rules/snake-case-table-name.js";
 
 const rules = {
+  "align-column-definitions": alignColumnDefinitions,
   "no-add-column-not-null-without-default": noAddColumnNotNullWithoutDefault,
   "no-alter-column-type": noAlterColumnType,
   "no-char-type": noCharType,
@@ -206,6 +208,7 @@ plugin.configs = {
       parser: postgresqlParser,
     },
     rules: {
+      "postgresql/align-column-definitions": "warn",
       "postgresql/no-unnecessary-quoted-identifier": "warn",
       "postgresql/prefer-as-for-column-alias": "warn",
       "postgresql/prefer-as-for-table-alias": "warn",

--- a/src/rules/align-column-definitions.ts
+++ b/src/rules/align-column-definitions.ts
@@ -1,0 +1,143 @@
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+import { isColumnDef, isConstraint } from "../utils/ast.js";
+
+// Minimum number of spaces to leave between adjacent fields when
+// aligning. Two spaces matches the convention in the user-supplied
+// example and is comfortably wide enough to be visually distinct.
+const GAP = 2;
+
+interface Slot {
+  node: Ast.ColumnDef;
+  name: string;
+  typeText: string;
+  // Source text from the position right after the type to the end of
+  // the last constraint. Empty string if the column has no constraints.
+  constraintsText: string;
+  // The full source range that this rule will rewrite. Starts at the
+  // column name and ends at the last constraint (or at the end of the
+  // type if there are no constraints).
+  rewriteStart: number;
+  rewriteEnd: number;
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "layout",
+    docs: {
+      description:
+        "Align column definitions vertically inside `CREATE TABLE` so that name, type, and constraints share consistent column offsets",
+      category: "Stylistic Issues",
+      recommended: false,
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      misaligned:
+        "Column definitions in this CREATE TABLE are not vertically aligned.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    return {
+      CreateStmt(node: Ast.CreateStmt) {
+        const elts = node.tableElts;
+        if (!Array.isArray(elts) || elts.length < 2) return;
+
+        // Only handle the simple case: every element in tableElts is a
+        // single-line ColumnDef. Table-level constraints, multi-line
+        // column definitions, and comma-sharing lines are out of scope —
+        // realigning them safely needs more careful source surgery than
+        // this rule does today.
+        const slots: Slot[] = [];
+        const seenLines = new Set<number>();
+        for (const elt of elts) {
+          if (!isColumnDef(elt)) return;
+          const colRange = elt.range;
+          const typeName = elt.typeName as
+            | { range?: [number, number] }
+            | undefined;
+          const typeRange = typeName?.range;
+          if (!colRange || !typeRange) return;
+          const constraints = Array.isArray(elt.constraints)
+            ? elt.constraints.filter(isConstraint)
+            : [];
+          const lastConstraint = constraints.at(-1);
+          const rewriteEnd = lastConstraint?.range
+            ? lastConstraint.range[1]
+            : typeRange[1];
+          const startLoc = sourceCode.getLocFromIndex(colRange[0]);
+          const endLoc = sourceCode.getLocFromIndex(rewriteEnd);
+          if (startLoc.line !== endLoc.line) return;
+          if (seenLines.has(startLoc.line)) return;
+          seenLines.add(startLoc.line);
+
+          const lineText = sourceCode.lines[startLoc.line - 1] ?? "";
+          // Reject lines that carry inline comments or any unexpected
+          // text in the rewrite span; we cannot safely reflow them.
+          if (lineText.includes("--") || lineText.includes("/*")) return;
+
+          const typeText = sourceCode
+            .getText()
+            .slice(typeRange[0], typeRange[1]);
+          const constraintsText = lastConstraint?.range
+            ? sourceCode
+                .getText()
+                .slice(typeRange[1], lastConstraint.range[1])
+                .trim()
+            : "";
+
+          slots.push({
+            node: elt,
+            name: elt.colname ?? "",
+            typeText,
+            constraintsText,
+            rewriteStart: colRange[0],
+            rewriteEnd,
+          });
+        }
+        if (slots.length < 2) return;
+
+        const maxName = Math.max(...slots.map((s) => s.name.length));
+        const maxType = Math.max(...slots.map((s) => s.typeText.length));
+
+        let firstMisaligned: Slot | undefined;
+        const rewrites: Array<{ slot: Slot; replacement: string }> = [];
+        for (const slot of slots) {
+          const namePart = slot.name.padEnd(maxName);
+          const typePart = slot.constraintsText
+            ? slot.typeText.padEnd(maxType)
+            : slot.typeText;
+          const expected = slot.constraintsText
+            ? `${namePart}${" ".repeat(GAP)}${typePart}${" ".repeat(GAP)}${slot.constraintsText}`
+            : `${namePart}${" ".repeat(GAP)}${typePart}`;
+          const current = sourceCode
+            .getText()
+            .slice(slot.rewriteStart, slot.rewriteEnd);
+          if (current === expected) continue;
+          if (!firstMisaligned) firstMisaligned = slot;
+          rewrites.push({ slot, replacement: expected });
+        }
+        if (rewrites.length === 0 || !firstMisaligned) return;
+
+        context.report({
+          loc: {
+            start: sourceCode.getLocFromIndex(firstMisaligned.rewriteStart),
+            end: sourceCode.getLocFromIndex(firstMisaligned.rewriteEnd),
+          },
+          messageId: "misaligned",
+          fix(fixer) {
+            return rewrites.map(({ slot, replacement }) =>
+              fixer.replaceTextRange(
+                [slot.rewriteStart, slot.rewriteEnd],
+                replacement,
+              ),
+            );
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tests/align-column-definitions.test.ts
+++ b/tests/align-column-definitions.test.ts
@@ -1,0 +1,8 @@
+import rule from "../src/rules/align-column-definitions.js";
+import { runRuleTest } from "./test-utils.js";
+
+runRuleTest(
+  "align-column-definitions",
+  rule,
+  "Align column definitions vertically inside CREATE TABLE",
+);

--- a/tests/fixtures/align-column-definitions/invalid/misaligned-errors.expected.json
+++ b/tests/fixtures/align-column-definitions/invalid/misaligned-errors.expected.json
@@ -1,0 +1,1 @@
+[{ "messageId": "misaligned" }]

--- a/tests/fixtures/align-column-definitions/invalid/misaligned-output.expected.sql
+++ b/tests/fixtures/align-column-definitions/invalid/misaligned-output.expected.sql
@@ -1,0 +1,6 @@
+CREATE TABLE document_ingest_stage_executions (
+  document_ingest_stage_execution_id  ulid                            PRIMARY KEY,
+  tenant_id                           ulid                            NOT NULL,
+  agent_id                            ulid                            NOT NULL,
+  status                              flygate_document_ingest_status  NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/invalid/misaligned.sql
+++ b/tests/fixtures/align-column-definitions/invalid/misaligned.sql
@@ -1,0 +1,6 @@
+CREATE TABLE document_ingest_stage_executions (
+  document_ingest_stage_execution_id ulid PRIMARY KEY,
+  tenant_id ulid NOT NULL,
+  agent_id ulid NOT NULL,
+  status flygate_document_ingest_status NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/invalid/mixed-constraints-errors.expected.json
+++ b/tests/fixtures/align-column-definitions/invalid/mixed-constraints-errors.expected.json
@@ -1,0 +1,1 @@
+[{ "messageId": "misaligned" }]

--- a/tests/fixtures/align-column-definitions/invalid/mixed-constraints-output.expected.sql
+++ b/tests/fixtures/align-column-definitions/invalid/mixed-constraints-output.expected.sql
@@ -1,0 +1,5 @@
+CREATE TABLE foo (
+  id           ulid              PRIMARY KEY,
+  description  text,
+  created_at   flygate_datetime  NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/invalid/mixed-constraints.sql
+++ b/tests/fixtures/align-column-definitions/invalid/mixed-constraints.sql
@@ -1,0 +1,5 @@
+CREATE TABLE foo (
+  id ulid PRIMARY KEY,
+  description text,
+  created_at flygate_datetime NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/valid/already-aligned.sql
+++ b/tests/fixtures/align-column-definitions/valid/already-aligned.sql
@@ -1,0 +1,6 @@
+CREATE TABLE document_ingest_stage_executions (
+  document_ingest_stage_execution_id  ulid                            PRIMARY KEY,
+  tenant_id                           ulid                            NOT NULL,
+  agent_id                            ulid                            NOT NULL,
+  status                              flygate_document_ingest_status  NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/valid/has-inline-comment.sql
+++ b/tests/fixtures/align-column-definitions/valid/has-inline-comment.sql
@@ -1,0 +1,5 @@
+-- Inline comments would be clobbered by a naive realign; skip.
+CREATE TABLE foo (
+  id ulid PRIMARY KEY, -- the surrogate key
+  name text NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/valid/has-table-constraint.sql
+++ b/tests/fixtures/align-column-definitions/valid/has-table-constraint.sql
@@ -1,0 +1,7 @@
+-- The rule does not realign tables that mix column defs with table-level
+-- constraints, since the safe rewrite for those is more involved.
+CREATE TABLE foo (
+  id ulid,
+  name text,
+  PRIMARY KEY (id, name)
+);

--- a/tests/fixtures/align-column-definitions/valid/single-column.sql
+++ b/tests/fixtures/align-column-definitions/valid/single-column.sql
@@ -1,0 +1,3 @@
+CREATE TABLE only_one (
+  id ulid PRIMARY KEY
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `postgresql/align-column-definitions` to `configs.stylistic`. Aligns column definitions inside `CREATE TABLE` so that name, type, and constraints share consistent column offsets across rows. Auto-fixable.

## Motivation

Requested in conversation:

```sql
CREATE TABLE document_ingest_stage_executions (
  document_ingest_stage_execution_id  ulid                            PRIMARY KEY,
  tenant_id                           ulid                            NOT NULL,
  agent_id                            ulid                            NOT NULL,
  ...
);
```

PostgreSQL formatters (`prettier-plugin-sql`, `pg_format`) don't enforce this style, so it belongs in the stylistic preset.

## Changes

- New rule `src/rules/align-column-definitions.ts`. Visits `CreateStmt`, walks `tableElts`, and for the simple all-`ColumnDef` case computes the longest `colname` and longest type-source-slice. Each row's `nameStart..lastConstraintEnd` source range is rewritten with `name.padEnd(maxName) + GAP + type.padEnd(maxType) + GAP + constraints` (or no constraints + no trailing GAP if the column has none). Reports once per misaligned table with autofix that touches all out-of-spec rows at once.

- Conservative skip conditions:
  - Any `tableElts` entry is a table-level Constraint (e.g. `PRIMARY KEY (a, b)`).
  - Any column definition spans more than one line.
  - Two ColumnDefs share a line.
  - A column line carries an inline `--` or `/*` comment.

  Realigning these safely needs more careful source surgery and is deferred.

- Test fixtures: misaligned-and-fixed, mixed-with/without-constraints, already-aligned, single-column, table-level-constraint-skip, inline-comment-skip.

- README rule-table entry, changeset.

## Testing

```bash
pnpm test:all
```

All gates green. New rule contributes one test with 4 valid fixtures and 2 invalid fixtures (each with the autofix output asserted).

## Breaking changes

None. Off by default unless the consumer opts into `configs.stylistic`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->