### PR TITLE
feat(align-column-definitions): add gap option and accept table-level constraints

### DIFF
--- a/.changeset/align-column-definitions-enhancements.md
+++ b/.changeset/align-column-definitions-enhancements.md
@@ -1,0 +1,12 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+`postgresql/align-column-definitions`:
+
+- New `gap` option (integer, default `2`) controls the minimum number of
+  spaces inserted between the name / type / constraints lanes.
+- Tables that mix column definitions with table-level constraints
+  (`PRIMARY KEY (a, b)`, `CHECK (...)`, etc.) are now realigned. The
+  table-level constraint rows are preserved as-is; only the ColumnDef
+  rows are touched.

--- a/src/rules/align-column-definitions.ts
+++ b/src/rules/align-column-definitions.ts
@@ -2,10 +2,10 @@ import type { Rule } from "eslint";
 import type { Ast } from "postgresql-eslint-parser";
 import { isColumnDef, isConstraint } from "../utils/ast.js";
 
-// Minimum number of spaces to leave between adjacent fields when
+// Default minimum number of spaces between adjacent fields when
 // aligning. Two spaces matches the convention in the user-supplied
 // example and is comfortably wide enough to be visually distinct.
-const GAP = 2;
+const DEFAULT_GAP = 2;
 
 interface Slot {
   node: Ast.ColumnDef;
@@ -31,7 +31,15 @@ const rule: Rule.RuleModule = {
       recommended: false,
     },
     fixable: "code",
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          gap: { type: "integer", minimum: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       misaligned:
         "Column definitions in this CREATE TABLE are not vertically aligned.",
@@ -39,20 +47,21 @@ const rule: Rule.RuleModule = {
   },
   create(context) {
     const sourceCode = context.sourceCode;
+    const option = (context.options[0] ?? {}) as { gap?: number };
+    const gap = option.gap ?? DEFAULT_GAP;
     return {
       CreateStmt(node: Ast.CreateStmt) {
         const elts = node.tableElts;
-        if (!Array.isArray(elts) || elts.length < 2) return;
+        if (!Array.isArray(elts) || elts.length === 0) return;
 
-        // Only handle the simple case: every element in tableElts is a
-        // single-line ColumnDef. Table-level constraints, multi-line
-        // column definitions, and comma-sharing lines are out of scope —
-        // realigning them safely needs more careful source surgery than
-        // this rule does today.
+        // Table-level constraints (`PRIMARY KEY (a, b)`, `CHECK (...)`,
+        // etc.) are kept as-is — only ColumnDef rows are realigned. Walk
+        // every element so we still bail out on multi-line column defs
+        // and shared-line layouts, where source surgery is unsafe.
         const slots: Slot[] = [];
         const seenLines = new Set<number>();
         for (const elt of elts) {
-          if (!isColumnDef(elt)) return;
+          if (!isColumnDef(elt)) continue;
           const colRange = elt.range;
           const typeName = elt.typeName as
             | { range?: [number, number] }
@@ -109,8 +118,8 @@ const rule: Rule.RuleModule = {
             ? slot.typeText.padEnd(maxType)
             : slot.typeText;
           const expected = slot.constraintsText
-            ? `${namePart}${" ".repeat(GAP)}${typePart}${" ".repeat(GAP)}${slot.constraintsText}`
-            : `${namePart}${" ".repeat(GAP)}${typePart}`;
+            ? `${namePart}${" ".repeat(gap)}${typePart}${" ".repeat(gap)}${slot.constraintsText}`
+            : `${namePart}${" ".repeat(gap)}${typePart}`;
           const current = sourceCode
             .getText()
             .slice(slot.rewriteStart, slot.rewriteEnd);

--- a/tests/fixtures/align-column-definitions/invalid/with-table-constraint-errors.expected.json
+++ b/tests/fixtures/align-column-definitions/invalid/with-table-constraint-errors.expected.json
@@ -1,0 +1,1 @@
+[{ "messageId": "misaligned" }]

--- a/tests/fixtures/align-column-definitions/invalid/with-table-constraint-output.expected.sql
+++ b/tests/fixtures/align-column-definitions/invalid/with-table-constraint-output.expected.sql
@@ -1,0 +1,6 @@
+CREATE TABLE foo (
+  id     ulid,
+  name   text,
+  email  text,
+  PRIMARY KEY (id, email)
+);

--- a/tests/fixtures/align-column-definitions/invalid/with-table-constraint.sql
+++ b/tests/fixtures/align-column-definitions/invalid/with-table-constraint.sql
@@ -1,0 +1,6 @@
+CREATE TABLE foo (
+  id ulid,
+  name text,
+  email text,
+  PRIMARY KEY (id, email)
+);

--- a/tests/fixtures/align-column-definitions/valid/has-table-constraint.sql
+++ b/tests/fixtures/align-column-definitions/valid/has-table-constraint.sql
@@ -1,7 +1,0 @@
--- The rule does not realign tables that mix column defs with table-level
--- constraints, since the safe rewrite for those is more involved.
-CREATE TABLE foo (
-  id ulid,
-  name text,
-  PRIMARY KEY (id, name)
-);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Two extensions to `postgresql/align-column-definitions`:

1. New `gap` option (integer, default `2`) controls the minimum spaces between aligned lanes.
2. Tables that mix ColumnDef rows with table-level Constraint rows are now realigned (the Constraint rows pass through untouched).

## Motivation

The rule originally bailed on any table containing a table-level constraint (`PRIMARY KEY (a, b)`, `CHECK (...)`, etc.) — which is most real-world tables. Realigning the surrounding ColumnDef rows is straightforward; we only need to skip the Constraint rows when computing widths and when emitting fixes. The `gap` option falls out naturally so users who prefer 1 or 4 spaces aren't forced to fork.

## Changes

- `src/rules/align-column-definitions.ts`:
  - Schema gains `{ gap: integer >= 1 }`.
  - `for...of elts` skips non-ColumnDef entries (`continue`) instead of bailing the whole table.
  - `GAP` constant becomes `option.gap ?? 2`.
- Replaced the now-obsolete `valid/has-table-constraint.sql` fixture (which covered the old skip behavior) with `invalid/with-table-constraint.sql` (which exercises the new "align around it" behavior, with the `PRIMARY KEY` row preserved verbatim).

## Testing

```bash
pnpm test:all
```

All gates green.

## Breaking changes

Behavior change for tables that mix ColumnDef and table-level Constraint rows: those tables are now realigned where they were previously left alone. Per CLAUDE.md guidance for stylistic rules, this is documented in the changeset; opt-out is `--rule postgresql/align-column-definitions:off` per file or via overrides.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->