### PR TITLE
feat: add configs.all that enables every rule at error

### DIFF
--- a/.changeset/configs-all.md
+++ b/.changeset/configs-all.md
@@ -1,0 +1,8 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `configs.all`: every rule the plugin ships, enabled at `error`.
+Built mechanically from `plugin.rules`, so any rule added later is
+automatically included. Intended for users who want to audit the full
+catalog and turn off only what they actively don't want.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,14 +76,19 @@ For a lint plugin, this translates concretely:
 
 - **One rule per concern.** Don't add `no-foo` and `prefer-not-foo` when one
   rule with an option covers it.
-- **`configs.recommended` is the canonical preset for correctness.** Don't add
-  `configs.strict` / `configs.loose` / `configs.all` just to expose different
-  severity sets — users can flip severities per rule themselves.
+- **`configs.recommended` is the canonical preset for correctness.** Don't
+  add `configs.strict` / `configs.loose` to expose different severity sets
+  for the same rules — users can flip severities per rule themselves.
 - **`configs.stylistic` is the second preset, for layout / casing / formatting
   rules only.** It exists because PostgreSQL formatters (`prettier-plugin-sql`,
   `pg_format`) do not cover PL/pgSQL well, and because correctness and style
   are genuinely orthogonal axes that users opt into independently. Stylistic
   rules MUST be `fixable`. Do not split it further (no `stylistic-strict` etc).
+- **`configs.all` is the third preset.** Every rule the plugin ships,
+  enabled at `error`. Maintained mechanically: when you add a rule, also
+  add it to `all`. The `index.test.ts` smoke test enforces that `all`
+  references every rule in `plugin.rules`. Off-by-default in practice
+  (it's noisy); intended for users who want to see everything and pick.
 - **Options are a last resort.** Each option is a forever-supported branch. If
   you can't name a real user with a real need, don't add the option.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ export default [
 ];
 ```
 
+### All preset (everything-on)
+
+`configs.all` enables every rule the plugin ships at `error`. It is
+deliberately noisy — useful for exploring what the plugin can catch, or
+for greenfield projects that want to audit and then disable rules they
+don't want. Not recommended for an existing codebase without overrides.
+
+```js
+import postgresql from "eslint-plugin-postgresql";
+
+export default [
+  {
+    files: ["**/*.sql"],
+    ...postgresql.configs.all,
+  },
+];
+```
+
 ## Rules
 
 Click a rule name to open its documentation page (examples, rationale, options).

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,22 @@ plugin.configs = {
       "postgresql/require-trailing-semicolon": "warn",
     },
   } satisfies Linter.Config,
+  // Every rule the plugin ships, enabled at `error`. Built mechanically
+  // from `rules` so adding a new rule automatically opts it into `all`
+  // — see the matching invariant test in tests/index.test.ts.
+  all: {
+    files: ["**/*.sql"],
+    plugins: { postgresql: plugin },
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: Object.fromEntries(
+      Object.keys(rules).map((name) => [
+        `postgresql/${name}`,
+        "error" as const,
+      ]),
+    ),
+  } satisfies Linter.Config,
 };
 
 export default plugin;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -53,6 +53,38 @@ describe("eslint-plugin-postgresql", () => {
     }
   });
 
+  it("ships configs.all that enables every plugin rule at error", () => {
+    const all = plugin.configs?.["all"];
+    expect(all).toBeDefined();
+    if (!all || typeof all !== "object") return;
+
+    const plugins = (all as { plugins?: Record<string, unknown> }).plugins;
+    expect(plugins?.["postgresql"]).toBe(plugin);
+
+    const rules = (all as { rules?: Record<string, unknown> }).rules ?? {};
+    const referenced = Object.keys(rules)
+      .filter((k) => k.startsWith("postgresql/"))
+      .map((k) => k.slice("postgresql/".length));
+
+    // Every rule the plugin ships must appear in `all`. This is the
+    // invariant that lets us add a new rule without remembering to
+    // wire it into `all` separately — the test fails until you do.
+    const shipped = Object.keys(plugin.rules ?? {});
+    for (const ruleName of shipped) {
+      expect(
+        rules[`postgresql/${ruleName}`],
+        `all is missing rule "${ruleName}"`,
+      ).toBe("error");
+    }
+    // And `all` must not reference rules that don't exist.
+    for (const ruleName of referenced) {
+      expect(
+        plugin.rules?.[ruleName],
+        `all references unknown rule "${ruleName}"`,
+      ).toBeDefined();
+    }
+  });
+
   it("ships configs.stylistic that only references fixable rules", () => {
     const stylistic = plugin.configs?.["stylistic"];
     expect(stylistic).toBeDefined();


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds a third preset, `configs.all`, that turns every rule the plugin ships on at severity `error`.

## Motivation

Maintainer-requested: an everything-on preset that lets users audit the full catalog and turn off only what they actively don't want, without hand-listing each rule. Distinct from the previously-prohibited `configs.strict` / `configs.loose` patterns: `all` does not duplicate severities — there's one canonical severity (`error`) for every rule, scoped to the full catalog.

## Changes

- `src/index.ts`: `configs.all` is built mechanically from `Object.keys(rules)`, so any rule added later is automatically opted in. No risk of drift.
- `tests/index.test.ts`: new smoke test enforces both directions of the invariant — every shipped rule is in `all`, and no entry in `all` references a non-existent rule.
- `README.md`: new "All preset (everything-on)" section under Usage, with a code sample.
- `CLAUDE.md`: updated the "one canonical preset" rule to record `all` as the third allowed preset, with the rationale (it's a single severity per rule, not a parallel dialect).
- Changeset attached (minor bump).

## Testing

```bash
pnpm test:all
```

All gates green. The new smoke test catches future drift if someone removes a rule but leaves it in `all`, or adds a rule and forgets to update `all`.

## Breaking changes

None. `configs.all` is additive and opt-in. Existing `configs.recommended` and `configs.stylistic` are unchanged.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->