### PR TITLE
fix: address #132, #136, #137; bump parser to ^0.5.0

### DIFF
--- a/.changeset/issue-batch.md
+++ b/.changeset/issue-batch.md
@@ -1,0 +1,22 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Three issues fixed plus a parser dep bump:
+
+- **#136 fix:** `require-trailing-semicolon` no longer appends a run of
+  bare `;` characters at EOF when the file contains a parser-level
+  syntax error. The rule now skips `SQLParseError` body entries; their
+  range covers the whole file (or its tail) and inserting `;` cannot
+  turn malformed SQL into valid SQL.
+- **#137 fix:** `align-column-definitions` now treats parameterized
+  types like `TIMESTAMP(3)`, `VARCHAR(255)`, `NUMERIC(10, 2)` as a
+  single alignment column. Previously the bare type name and its
+  `(...)` modifier landed in different lanes, splitting `TIMESTAMP(3)`
+  into `TIMESTAMP  (3)` and dragging the type column's width down.
+- **#132 feat:** `snake-case-column-name` and `snake-case-table-name`
+  gain a shared `allow` option (`string[]`, default `[]`). Listed
+  identifiers are exempted from the snake_case check by exact-match.
+  Default behavior is unchanged.
+- Bumps `postgresql-eslint-parser` to `^0.5.0`, which fixes inner-node
+  range aggregation for descendants without observed locations.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   },
   "dependencies": {
     "libpg-query": "^17.1.1",
-    "postgresql-eslint-parser": "^0.4.0"
+    "postgresql-eslint-parser": "^0.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^17.1.1
         version: 17.1.1(encoding@0.1.13)
       postgresql-eslint-parser:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.1
@@ -1768,8 +1768,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postgresql-eslint-parser@0.4.0:
-    resolution: {integrity: sha512-9HsJu0sh6y+mbwY9JkWohI7e9RMZbscyrfl7bg0LqnMxp+FD3AK2ScV28o2+ndz3gdrK/hZrCg10W8HbFlOCSQ==}
+  postgresql-eslint-parser@0.5.0:
+    resolution: {integrity: sha512-fADwFLvAB5jmZaxm3Efw19uYfjeNDnEORc/LtmkkuzhE90x40D6nKM0m8/wk0UzUAK37pNpqfTahuK23PwOdjA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.14.0'}
 
   prelude-ls@1.2.1:
@@ -3852,7 +3852,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgresql-eslint-parser@0.4.0:
+  postgresql-eslint-parser@0.5.0:
     dependencies:
       '@libpg-query/parser': 17.6.3
 

--- a/src/rules/align-column-definitions.ts
+++ b/src/rules/align-column-definitions.ts
@@ -60,14 +60,32 @@ const rule: Rule.RuleModule = {
         // and shared-line layouts, where source surgery is unsafe.
         const slots: Slot[] = [];
         const seenLines = new Set<number>();
+        const tokens = sourceCode.ast.tokens ?? [];
         for (const elt of elts) {
           if (!isColumnDef(elt)) continue;
           const colRange = elt.range;
           const typeName = elt.typeName as
-            | { range?: [number, number] }
+            | {
+                range?: [number, number];
+                typmods?: { range?: [number, number] }[];
+              }
             | undefined;
-          const typeRange = typeName?.range;
-          if (!colRange || !typeRange) return;
+          const baseTypeRange = typeName?.range;
+          if (!colRange || !baseTypeRange) return;
+          // The parser's `typeName.range` covers only the bare type
+          // name. For parameterized types like `TIMESTAMP(3)` or
+          // `NUMERIC(10, 2)`, the modifier list lives in `typmods`; we
+          // extend the type span through the closing `)` so the rule
+          // sees the whole `TYPE(...)` as one alignment column.
+          let typeEnd = baseTypeRange[1];
+          const lastTypmod = typeName?.typmods?.at(-1);
+          if (lastTypmod?.range) {
+            const closingParen = tokens.find(
+              (t) => t.range[0] >= lastTypmod.range![1] && t.value === ")",
+            );
+            if (closingParen) typeEnd = closingParen.range[1];
+          }
+          const typeRange: [number, number] = [baseTypeRange[0], typeEnd];
           const constraints = Array.isArray(elt.constraints)
             ? elt.constraints.filter(isConstraint)
             : [];

--- a/src/rules/require-trailing-semicolon.ts
+++ b/src/rules/require-trailing-semicolon.ts
@@ -21,6 +21,12 @@ const rule: Rule.RuleModule = {
         if (!Array.isArray(body)) return;
         const tokens = context.sourceCode.ast.tokens ?? [];
         for (const stmt of body) {
+          // Skip parse-error placeholders. Their range covers the whole
+          // file (or the trailing tail of it), and inserting `;` cannot
+          // turn malformed SQL into valid SQL — the rule would just
+          // accumulate one `;` per autofix pass.
+          const type = (stmt as { type?: unknown }).type;
+          if (type === "SQLParseError") continue;
           const range = (stmt as { range?: [number, number] }).range;
           const loc = (stmt as { loc?: AST.SourceLocation }).loc;
           if (!range || !loc) continue;

--- a/src/rules/snake-case-column-name.ts
+++ b/src/rules/snake-case-column-name.ts
@@ -12,23 +12,38 @@ const rule: Rule.RuleModule = {
       recommended: true,
     },
     fixable: undefined,
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allow: {
+            type: "array",
+            items: { type: "string" },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       notSnakeCase:
         "Column name `{{name}}` is not snake_case. PostgreSQL preserves the case of quoted identifiers; using a mixed-case quoted name forces every consumer to quote-match it.",
     },
   },
   create(context) {
+    const option = (context.options[0] ?? {}) as { allow?: string[] };
+    const allow = new Set(option.allow ?? []);
     return {
       ColumnDef(node: Ast.ColumnDef) {
         const name = node.colname;
-        if (typeof name === "string" && !SNAKE_CASE.test(name)) {
-          context.report({
-            node: node as unknown as Rule.Node,
-            messageId: "notSnakeCase",
-            data: { name },
-          });
-        }
+        if (typeof name !== "string") return;
+        if (allow.has(name)) return;
+        if (SNAKE_CASE.test(name)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "notSnakeCase",
+          data: { name },
+        });
       },
     };
   },

--- a/src/rules/snake-case-table-name.ts
+++ b/src/rules/snake-case-table-name.ts
@@ -12,24 +12,39 @@ const rule: Rule.RuleModule = {
       recommended: true,
     },
     fixable: undefined,
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allow: {
+            type: "array",
+            items: { type: "string" },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       notSnakeCase:
         'Table name `{{name}}` is not snake_case. PostgreSQL folds unquoted identifiers to lower case but preserves the case of quoted identifiers; mixing the two leads to `relation "BadName" does not exist` errors that are confusing to debug.',
     },
   },
   create(context) {
+    const option = (context.options[0] ?? {}) as { allow?: string[] };
+    const allow = new Set(option.allow ?? []);
     return {
       CreateStmt(node: Ast.CreateStmt) {
         const relation = node.relation as { relname?: unknown } | undefined;
         const name = relation?.relname;
-        if (typeof name === "string" && !SNAKE_CASE.test(name)) {
-          context.report({
-            node: node as unknown as Rule.Node,
-            messageId: "notSnakeCase",
-            data: { name },
-          });
-        }
+        if (typeof name !== "string") return;
+        if (allow.has(name)) return;
+        if (SNAKE_CASE.test(name)) return;
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: "notSnakeCase",
+          data: { name },
+        });
       },
     };
   },

--- a/tests/fixtures/align-column-definitions/invalid/type-with-precision-errors.expected.json
+++ b/tests/fixtures/align-column-definitions/invalid/type-with-precision-errors.expected.json
@@ -1,0 +1,1 @@
+[{ "messageId": "misaligned" }]

--- a/tests/fixtures/align-column-definitions/invalid/type-with-precision-output.expected.sql
+++ b/tests/fixtures/align-column-definitions/invalid/type-with-precision-output.expected.sql
@@ -1,0 +1,6 @@
+CREATE TABLE pgmigration_triggers (
+  id         BIGSERIAL     PRIMARY KEY,
+  name       TEXT          NOT NULL,
+  file_hash  TEXT          NOT NULL,
+  run_on     TIMESTAMP(3)  NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/invalid/type-with-precision.sql
+++ b/tests/fixtures/align-column-definitions/invalid/type-with-precision.sql
@@ -1,0 +1,6 @@
+CREATE TABLE pgmigration_triggers (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  file_hash TEXT NOT NULL,
+  run_on TIMESTAMP(3) NOT NULL
+);

--- a/tests/fixtures/require-trailing-semicolon/valid/parse-error-stays-untouched.sql
+++ b/tests/fixtures/require-trailing-semicolon/valid/parse-error-stays-untouched.sql
@@ -1,0 +1,5 @@
+-- Regression test for #136: SET ... = NULL is rejected by libpg-query.
+-- The rule must skip parse-error stmts so autofix does not append a
+-- run of `;` characters to the file.
+SET LOCAL app.admin = 'true';
+SET plv8.start_proc = NULL;

--- a/tests/fixtures/snake-case-column-name/invalid/allow-list-partial-errors.expected.json
+++ b/tests/fixtures/snake-case-column-name/invalid/allow-list-partial-errors.expected.json
@@ -1,0 +1,1 @@
+[{ "messageId": "notSnakeCase" }]

--- a/tests/fixtures/snake-case-column-name/invalid/allow-list-partial-options.json
+++ b/tests/fixtures/snake-case-column-name/invalid/allow-list-partial-options.json
@@ -1,0 +1,1 @@
+[{ "allow": ["userId"] }]

--- a/tests/fixtures/snake-case-column-name/invalid/allow-list-partial.sql
+++ b/tests/fixtures/snake-case-column-name/invalid/allow-list-partial.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t (
+  "userId" int,
+  "createdAt" timestamptz
+);

--- a/tests/fixtures/snake-case-column-name/valid/allow-list-options.json
+++ b/tests/fixtures/snake-case-column-name/valid/allow-list-options.json
@@ -1,0 +1,1 @@
+[{ "allow": ["userId", "createdAt"] }]

--- a/tests/fixtures/snake-case-column-name/valid/allow-list.sql
+++ b/tests/fixtures/snake-case-column-name/valid/allow-list.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t (
+  "userId" int,
+  "createdAt" timestamptz
+);

--- a/tests/fixtures/snake-case-table-name/valid/allow-list-options.json
+++ b/tests/fixtures/snake-case-table-name/valid/allow-list-options.json
@@ -1,0 +1,1 @@
+[{ "allow": ["LegacyOrders"] }]

--- a/tests/fixtures/snake-case-table-name/valid/allow-list.sql
+++ b/tests/fixtures/snake-case-table-name/valid/allow-list.sql
@@ -1,0 +1,1 @@
+CREATE TABLE LegacyOrders (id int);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -15,17 +15,35 @@ const createRuleTester = () => {
   });
 };
 
+const readOptionsFor = (
+  folderPath: string,
+  baseName: string,
+): unknown[] | undefined => {
+  try {
+    return JSON.parse(
+      readFileSync(join(folderPath, `${baseName}-options.json`), "utf-8"),
+    );
+  } catch {
+    return undefined;
+  }
+};
+
 // Fixtureファイルを読み込む共通関数
 const readFixtureFiles = (
   folderPath: string,
-): Array<{ code: string; filename: string }> => {
+): Array<{ code: string; filename: string; options?: unknown[] }> => {
   const files = readdirSync(folderPath);
   return files
     .filter((file) => file.endsWith(".sql"))
-    .map((file) => ({
-      code: readFileSync(join(folderPath, file), "utf-8").trim(),
-      filename: file,
-    }));
+    .map((file) => {
+      const baseName = file.replace(".sql", "");
+      const options = readOptionsFor(folderPath, baseName);
+      return {
+        code: readFileSync(join(folderPath, file), "utf-8").trim(),
+        filename: file,
+        ...(options !== undefined ? { options } : {}),
+      };
+    });
 };
 
 // Invalid fixtureを読み込む共通関数
@@ -52,11 +70,14 @@ const readInvalidFixtures = (folderPath: string) => {
       output = undefined;
     }
 
+    const options = readOptionsFor(folderPath, baseName);
+
     return {
       code: readFileSync(join(folderPath, file), "utf-8").trim(),
       filename: file,
       errors,
       ...(output !== undefined ? { output } : {}),
+      ...(options !== undefined ? { options } : {}),
     };
   });
 };


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Three open issues fixed in one PR plus a parser dep bump:

- Closes #136 — `require-trailing-semicolon` no longer accumulates a run of `;` at EOF when the file has a parser-level syntax error.
- Closes #137 — `align-column-definitions` keeps `TYPE(precision)` together as a single alignment column.
- Closes #132 — `snake-case-column-name` / `snake-case-table-name` gain an `allow` option for exempt identifiers.

## Motivation

All three were filed as user-visible bugs/feature against `eslint-plugin-postgresql@0.4.0`. The `allow` option is the explicit alternative to scattering `eslint-disable-next-line` across a codebase for legacy or vendor-locked names; the two bugs both fired in real config (`configs.all`) and produced clearly wrong autofix output.

## Changes

- `src/rules/require-trailing-semicolon.ts`: skip `SQLParseError` body entries. They aren't real statements — their range covers the whole file's failed-to-parse tail, so inserting `;` at `range[1]` accumulates one `;` per autofix pass until ESLint's pass cap kicks in.

- `src/rules/align-column-definitions.ts`: when a column's `typeName.typmods` is non-empty, scan tokens forward from the last typmod's end and extend the type span through the matching `)`. The rest of the rule already operated on a `typeRange`, so this slots in cleanly.

- `src/rules/snake-case-column-name.ts` / `snake-case-table-name.ts`: schema gains `{ allow: string[] }`. The rule short-circuits when the candidate name is an exact match in the allow set. Default `[]` keeps existing behavior.

- `tests/test-utils.ts`: load an optional `<basename>-options.json` per fixture and pass it through to RuleTester. Lets the existing fixture-driven test framework cover option-parameterized rules without a parallel test path.

- New fixtures cover each fix; existing fixtures unchanged.

## Testing

```bash
pnpm test:all
```

All gates green. Each fix has a dedicated fixture (`require-trailing-semicolon/valid/parse-error-stays-untouched.sql`, `align-column-definitions/invalid/type-with-precision.sql`, `snake-case-column-name/{valid,invalid}/allow-list*`, `snake-case-table-name/valid/allow-list*`).

## Breaking changes

None. The bug fixes change behavior only for previously-broken cases; the new `allow` option defaults to empty.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->