### PR TITLE
fix(align-column-definitions): allow trailing inline comments

### DIFF
--- a/.changeset/align-inline-comment.md
+++ b/.changeset/align-inline-comment.md
@@ -7,5 +7,5 @@ trailing `--` or `/* */` comment after the constraints (e.g.
 `id ulid PRIMARY KEY, -- the surrogate key`). Previously the rule
 bailed on the whole table when any line had a comment, even when the
 comment was safely outside the rewrite range. Inline comments
-*inside* a column's name/type/constraints span are still skipped
+_inside_ a column's name/type/constraints span are still skipped
 (rewriting them would clobber the comment text).

--- a/.changeset/align-inline-comment.md
+++ b/.changeset/align-inline-comment.md
@@ -1,0 +1,11 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+`align-column-definitions` now realigns column rows that carry a
+trailing `--` or `/* */` comment after the constraints (e.g.
+`id ulid PRIMARY KEY, -- the surrogate key`). Previously the rule
+bailed on the whole table when any line had a comment, even when the
+comment was safely outside the rewrite range. Inline comments
+*inside* a column's name/type/constraints span are still skipped
+(rewriting them would clobber the comment text).

--- a/src/rules/align-column-definitions.ts
+++ b/src/rules/align-column-definitions.ts
@@ -117,10 +117,21 @@ const rule: Rule.RuleModule = {
           if (seenLines.has(startLoc.line)) return;
           seenLines.add(startLoc.line);
 
-          const lineText = sourceCode.lines[startLoc.line - 1] ?? "";
-          // Reject lines that carry inline comments or any unexpected
-          // text in the rewrite span; we cannot safely reflow them.
-          if (lineText.includes("--") || lineText.includes("/*")) return;
+          // A `--` or `/* */` comment AFTER the rewrite range is fine —
+          // the rule only replaces [name..lastConstraint] and never
+          // touches the trailing comma or comment that follows.
+          // Reject only when a comment lives INSIDE the rewrite span
+          // (e.g. `id /* annotation */ ulid PRIMARY KEY`), since that
+          // text would be clobbered by the realigned line.
+          const rewriteSpanText = sourceCode
+            .getText()
+            .slice(colRange[0], rewriteEnd);
+          if (
+            rewriteSpanText.includes("--") ||
+            rewriteSpanText.includes("/*")
+          ) {
+            return;
+          }
 
           const typeText = sourceCode
             .getText()

--- a/tests/fixtures/align-column-definitions/invalid/inline-comment-errors.expected.json
+++ b/tests/fixtures/align-column-definitions/invalid/inline-comment-errors.expected.json
@@ -1,0 +1,1 @@
+[{ "messageId": "misaligned" }]

--- a/tests/fixtures/align-column-definitions/invalid/inline-comment-output.expected.sql
+++ b/tests/fixtures/align-column-definitions/invalid/inline-comment-output.expected.sql
@@ -1,0 +1,4 @@
+CREATE TABLE foo (
+  id    ulid  PRIMARY KEY, -- the surrogate key
+  name  text  NOT NULL
+);

--- a/tests/fixtures/align-column-definitions/invalid/inline-comment.sql
+++ b/tests/fixtures/align-column-definitions/invalid/inline-comment.sql
@@ -1,4 +1,3 @@
--- Inline comments would be clobbered by a naive realign; skip.
 CREATE TABLE foo (
   id ulid PRIMARY KEY, -- the surrogate key
   name text NOT NULL

--- a/tests/fixtures/align-column-definitions/valid/inline-comment-skipped-on-block-inside.sql
+++ b/tests/fixtures/align-column-definitions/valid/inline-comment-skipped-on-block-inside.sql
@@ -1,0 +1,6 @@
+-- Block comment INSIDE a column definition would be clobbered by the
+-- realign; the rule must skip the whole table in that case.
+CREATE TABLE foo (
+  id /* see ticket */ ulid PRIMARY KEY,
+  name text NOT NULL
+);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`align-column-definitions` now realigns column rows that carry a trailing `--` or `/* */` comment after the constraints. Previously the rule bailed on the whole table.

## Motivation

The trailing-comment skip was added as a conservative guard when the rule first shipped, but it's over-broad. A `-- the surrogate key` comment after `PRIMARY KEY,` lives **outside** the rewrite range (which is `[colName .. lastConstraint]`), so the realign never touches it. The previous behavior left realistically-commented tables un-realigned forever.

## Changes

- `src/rules/align-column-definitions.ts`: replace the line-level "any `--` or `/*` → bail" check with a span-level check on the rewrite range. Comments inside `[colName .. lastConstraint]` (e.g. `id /* see ticket */ ulid PRIMARY KEY`) still skip the table — those would actually get clobbered.
- The existing `valid/has-inline-comment.sql` fixture (which exercised the old skip) is moved to `invalid/inline-comment.sql` with the realigned output asserted.
- New `valid/inline-comment-skipped-on-block-inside.sql` locks in the conservative skip for the in-span case.

## Testing

```bash
pnpm test:all
```

All gates green. Diff between the new invalid input and the asserted output shows the realignment proceeds without disturbing the trailing comment text.

## Breaking changes

None at the API level. The behavior changes for previously-skipped tables (now realigned), which is what the rule's name promises. Treated as `patch` since it's narrowing an over-broad bail-out.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->