### PR TITLE
fix(require-limit): skip INSERT ... VALUES (closes #159)

### DIFF
--- a/.changeset/issue-159.md
+++ b/.changeset/issue-159.md
@@ -1,0 +1,8 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+Closes #159: `require-limit` no longer fires on
+`INSERT INTO ... VALUES (...)`. libpg-query rewrites the `VALUES`
+list as a synthetic `SelectStmt` with a populated `valuesLists`, and
+the rule now recognizes that shape and skips it.

--- a/src/rules/require-limit.ts
+++ b/src/rules/require-limit.ts
@@ -19,6 +19,14 @@ const rule: Rule.RuleModule = {
   create(context) {
     return {
       SelectStmt(node: Ast.SelectStmt) {
+        // libpg-query rewrites `INSERT INTO t VALUES (...)` as an
+        // InsertStmt whose `selectStmt` is a SelectStmt with a non-
+        // empty `valuesLists` and no `targetList` — i.e. a synthetic
+        // "SELECT of literal rows", not a user-written SELECT. LIMIT
+        // is meaningless there, so skip (#159).
+        const valuesLists = (node as { valuesLists?: unknown }).valuesLists;
+        if (Array.isArray(valuesLists) && valuesLists.length > 0) return;
+
         // A SELECT has a LIMIT if `limitCount` is set and `limitOption`
         // isn't the parser's default sentinel.
         const hasLimit =

--- a/tests/fixtures/require-limit/valid/insert-values-not-flagged.sql
+++ b/tests/fixtures/require-limit/valid/insert-values-not-flagged.sql
@@ -1,0 +1,6 @@
+-- Regression for #159: INSERT ... VALUES (...) is rewritten by
+-- libpg-query into a SelectStmt with `valuesLists`, but LIMIT has no
+-- meaning there.
+INSERT INTO t (id, name) VALUES
+  (1, 'alpha'),
+  (2, 'beta');


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Closes #159. `require-limit` no longer fires on `INSERT INTO ... VALUES (...)`.

## Motivation

libpg-query rewrites the `VALUES` list as a synthetic `SelectStmt` with a populated `valuesLists` and empty `targetList` — a "SELECT of literal rows", not a user-written SELECT. The rule was treating it as a normal SelectStmt and demanding LIMIT, which has no meaning for literal-row enumeration.

## Changes

- `src/rules/require-limit.ts`: skip when `node.valuesLists` is a non-empty array.
- `tests/fixtures/require-limit/valid/insert-values-not-flagged.sql`: regression fixture covering the user's reproducer.

## Testing

```bash
pnpm test:all
```

All gates green.

## Breaking changes

None — bug fix only narrows when the rule fires.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->