### PR TITLE
fix(plpgsql-keyword-case): exempt GET DIAGNOSTICS item names outside their statement

### DIFF
--- a/.changeset/plpgsql-keyword-case-diagnostic-names.md
+++ b/.changeset/plpgsql-keyword-case-diagnostic-names.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+Fix `plpgsql-keyword-case` false positives on `GET DIAGNOSTICS` item names used as regular identifiers. The rule was unconditionally flagging `row_count`, `column_name`, `table_name`, `schema_name`, `message_text`, `constraint_name`, `returned_sqlstate`, `pg_context`, `pg_datatype_name`, `pg_exception_context`, `pg_exception_detail`, and `pg_exception_hint` as keywords — but PostgreSQL only treats these as keywords on the right-hand side of `GET [STACKED] DIAGNOSTICS ... = `. Anywhere else (variable names in `DECLARE`, target of `SELECT INTO`, branch conditions, `information_schema` column references) they are ordinary identifiers, so the rule no longer reports them outside `GET DIAGNOSTICS` statements.

--- a/src/rules/plpgsql-keyword-case.ts
+++ b/src/rules/plpgsql-keyword-case.ts
@@ -15,6 +15,54 @@ const PLPGSQL = "plpgsql";
 // runs and reports those that match a known keyword.
 type SkipRange = readonly [number, number];
 
+// Identifiers that PostgreSQL only treats as keywords inside
+// `GET [STACKED] DIAGNOSTICS ... = <name>`. Everywhere else they are
+// ordinary identifiers (commonly used as variable names and as
+// `information_schema` column names), so we must not flag them.
+const DIAGNOSTIC_ITEM_NAMES: ReadonlySet<string> = new Set([
+  "row_count",
+  "pg_context",
+  "returned_sqlstate",
+  "column_name",
+  "constraint_name",
+  "pg_datatype_name",
+  "message_text",
+  "table_name",
+  "schema_name",
+  "pg_exception_detail",
+  "pg_exception_hint",
+  "pg_exception_context",
+]);
+
+// Find every `GET [STACKED] DIAGNOSTICS ... ;` span in the body so the
+// diagnostic item names inside are kept as keywords while the same
+// identifiers used elsewhere (variables, IS columns) are not.
+const findGetDiagnosticsRanges = (
+  source: string,
+  skip: SkipRange[],
+): SkipRange[] => {
+  const ranges: SkipRange[] = [];
+  const headRe = /\bget(\s+stacked)?\s+diagnostics\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = headRe.exec(source)) !== null) {
+    if (isInSkip(m.index, skip)) continue;
+    let end = m.index + m[0].length;
+    while (end < source.length) {
+      if (source[end] === ";" && !isInSkip(end, skip)) break;
+      end++;
+    }
+    ranges.push([m.index, end]);
+  }
+  return ranges;
+};
+
+const isInRange = (offset: number, ranges: SkipRange[]): boolean => {
+  for (const [s, e] of ranges) {
+    if (offset >= s && offset < e) return true;
+  }
+  return false;
+};
+
 const collectSkipRanges = (source: string): SkipRange[] => {
   const skip: SkipRange[] = [];
   for (let i = 0; i < source.length; i++) {
@@ -101,6 +149,7 @@ const rule: Rule.RuleModule = {
         if (!range) return;
         const source = node.source ?? "";
         const skip = collectSkipRanges(source);
+        const diagnosticsRanges = findGetDiagnosticsRanges(source, skip);
 
         const wordRe = /[a-zA-Z_][a-zA-Z0-9_]*/g;
         let match: RegExpExecArray | null;
@@ -110,6 +159,12 @@ const rule: Rule.RuleModule = {
           if (isInSkip(startInBody, skip)) continue;
           const lower = word.toLowerCase();
           if (!PLPGSQL_KEYWORDS.has(lower)) continue;
+          if (
+            DIAGNOSTIC_ITEM_NAMES.has(lower) &&
+            !isInRange(startInBody, diagnosticsRanges)
+          ) {
+            continue;
+          }
           const expected = transform(word);
           if (word === expected) continue;
           const absStart = range[0] + startInBody;

--- a/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower-errors.expected.json
+++ b/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower-errors.expected.json
@@ -1,0 +1,5 @@
+[
+  {
+    "messageId": "expectedUpper"
+  }
+]

--- a/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower-output.expected.sql
+++ b/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower-output.expected.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION example() RETURNS void
+LANGUAGE PLPGSQL
+AS $$
+DECLARE
+  affected INTEGER;
+BEGIN
+  UPDATE some_table SET x = 1;
+  GET DIAGNOSTICS affected = ROW_COUNT;
+END;
+$$;

--- a/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower.sql
+++ b/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION example() RETURNS void
+LANGUAGE PLPGSQL
+AS $$
+DECLARE
+  affected INTEGER;
+BEGIN
+  UPDATE some_table SET x = 1;
+  GET DIAGNOSTICS affected = row_count;
+END;
+$$;

--- a/tests/fixtures/plpgsql-keyword-case/valid/diagnostic-names-as-identifiers.sql
+++ b/tests/fixtures/plpgsql-keyword-case/valid/diagnostic-names-as-identifiers.sql
@@ -1,0 +1,19 @@
+CREATE FUNCTION example() RETURNS TRIGGER
+LANGUAGE PLPGSQL
+AS $$
+DECLARE
+  row_count INTEGER;
+  column_name TEXT;
+  table_name TEXT;
+  schema_name TEXT;
+  message_text TEXT;
+BEGIN
+  SELECT COUNT(*) INTO row_count FROM some_table;
+  IF row_count > 0 THEN
+    RAISE NOTICE 'rows: %', row_count;
+  END IF;
+  SELECT 'a', 'b', 'c'
+    INTO column_name, table_name, schema_name;
+  RETURN NEW;
+END;
+$$;

--- a/tests/fixtures/plpgsql-keyword-case/valid/get-diagnostics-upper.sql
+++ b/tests/fixtures/plpgsql-keyword-case/valid/get-diagnostics-upper.sql
@@ -1,0 +1,13 @@
+CREATE FUNCTION example() RETURNS void
+LANGUAGE PLPGSQL
+AS $$
+DECLARE
+  affected INTEGER;
+  state TEXT;
+BEGIN
+  UPDATE some_table SET x = 1;
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  GET STACKED DIAGNOSTICS state = RETURNED_SQLSTATE;
+  RAISE NOTICE '%, %', affected, state;
+END;
+$$;


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Fix the false positives reported in #188. The `plpgsql-keyword-case` rule was unconditionally treating PostgreSQL's `GET DIAGNOSTICS` item names (`row_count`, `column_name`, etc.) as keywords, so a perfectly valid PL/pgSQL variable named `row_count` was being flagged and auto-fixed to `ROW_COUNT` everywhere it appeared.

These identifiers are only keywords on the right-hand side of `GET [STACKED] DIAGNOSTICS ... = `. The rule now only flags them inside that span.

## Motivation

`row_count` is a natural variable name for "rows matching a condition" — a common pattern is `SELECT COUNT(*) INTO row_count FROM ...` followed by `IF row_count > 0 THEN`. The rule previously made this idiom unusable without renaming the variable. The same affects `column_name`, `table_name`, etc., all of which double as `information_schema` column names that often show up in PL/pgSQL bodies.

Closes #188

## Changes

- `src/rules/plpgsql-keyword-case.ts`: introduce `DIAGNOSTIC_ITEM_NAMES` (the 12 names PostgreSQL documents as `GET DIAGNOSTICS` items) and `findGetDiagnosticsRanges`, which locates every `GET [STACKED] DIAGNOSTICS ... ;` span in a PL/pgSQL body using the existing skip-range pass to avoid string-literal/comment hits. Inside the visitor, words in `DIAGNOSTIC_ITEM_NAMES` are only treated as keywords when they fall inside one of those spans.
- New fixtures:
  - `valid/diagnostic-names-as-identifiers.sql` — variables named `row_count`, `column_name`, `table_name`, `schema_name`, `message_text`; the reproduction case from #188 plus `SELECT INTO` targets.
  - `valid/get-diagnostics-upper.sql` — `GET DIAGNOSTICS affected = ROW_COUNT;` and `GET STACKED DIAGNOSTICS state = RETURNED_SQLSTATE;` (already upper-case, no diagnostics expected).
  - `invalid/get-diagnostics-lower.sql` + matching `errors.expected.json` and `output.expected.sql` — proves the rule still catches the in-context case and the fixer still rewrites to upper-case.

## Testing

- `pnpm test tests/plpgsql-keyword-case.test.ts` — passes.
- Full suite: `pnpm vitest run --dir tests` — 90 files / 97 tests passing.

## Breaking changes

None. The rule now reports fewer false positives; no fixture that was previously valid becomes invalid.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->