### PR TITLE
chore(deps): update dependency typescript to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier": "^3.8.3",
     "publint": "^0.3.21",
     "rolldown": "^1.0.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.6",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
@@ -1830,8 +1830,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3565,7 +3565,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   unbash@3.0.0: {}
 

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^24.12.4",
     "svelte": "^5.55.7",
     "svelte-check": "^4.4.8",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^5.4.21"
   },
   "dependencies": {

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -32,10 +32,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@5.9.3)(vite@5.4.21(@types/node@24.12.4)))
+        version: 3.0.10(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@6.0.3)(vite@5.4.21(@types/node@24.12.4)))
       '@sveltejs/kit':
         specifier: ^2.60.1
-        version: 2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@5.9.3)(vite@5.4.21(@types/node@24.12.4))
+        version: 2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@6.0.3)(vite@5.4.21(@types/node@24.12.4))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.4
         version: 4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4))
@@ -47,10 +47,10 @@ importers:
         version: 5.55.7
       svelte-check:
         specifier: ^4.4.8
-        version: 4.4.8(svelte@5.55.7)(typescript@5.9.3)
+        version: 4.4.8(svelte@5.55.7)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^5.4.21
         version: 5.4.21(@types/node@24.12.4)
@@ -600,8 +600,8 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -883,11 +883,11 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@5.9.3)(vite@5.4.21(@types/node@24.12.4)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@6.0.3)(vite@5.4.21(@types/node@24.12.4)))':
     dependencies:
-      '@sveltejs/kit': 2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@5.9.3)(vite@5.4.21(@types/node@24.12.4))
+      '@sveltejs/kit': 2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@6.0.3)(vite@5.4.21(@types/node@24.12.4))
 
-  '@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@5.9.3)(vite@5.4.21(@types/node@24.12.4))':
+  '@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(typescript@6.0.3)(vite@5.4.21(@types/node@24.12.4))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
@@ -905,7 +905,7 @@ snapshots:
       svelte: 5.55.7
       vite: 5.4.21(@types/node@24.12.4)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4)))(svelte@5.55.7)(vite@5.4.21(@types/node@24.12.4))':
     dependencies:
@@ -1083,7 +1083,7 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  svelte-check@4.4.8(svelte@5.55.7)(typescript@5.9.3):
+  svelte-check@4.4.8(svelte@5.55.7)(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
@@ -1091,7 +1091,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.55.7
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
 
@@ -1118,7 +1118,7 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
 


### PR DESCRIPTION
## Summary
- Bump `typescript` from `^5.9.3` to `^6.0.3` in both `package.json` and `site/package.json`.

## Test plan
- [x] `pnpm test:all` passes locally
- [x] `pnpm check` in `site/` passes locally