### PR TITLE
feat(deps): support eslint v10 in peer range

### DIFF
--- a/.changeset/eslint-v10-peer.md
+++ b/.changeset/eslint-v10-peer.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add `eslint@^10.0.0` to the peer dependency range, so the plugin can be used with ESLint v10 in addition to v8 and v9.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
-    "eslint": "^8.57.1 || ^9.0.0"
+    "eslint": "^8.57.1 || ^9.0.0 || ^10.0.0"
   },
   "dependencies": {
     "libpg-query": "^17.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       eslint:
-        specifier: ^8.57.1 || ^9.0.0
+        specifier: ^8.57.1 || ^9.0.0 || ^10.0.0
         version: 9.39.4(jiti@2.7.0)
       libpg-query:
         specifier: ^17.1.1


### PR DESCRIPTION
## Summary
- Expand `peerDependencies.eslint` range from `^8.57.1 || ^9.0.0` to also accept `^10.0.0`.
- Additive change — users on ESLint v8/v9 are unaffected.

## Test plan
- [x] `pnpm test:all` passes locally