### PR TITLE
chore(deps): update pnpm to v11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-postgresql",
   "version": "0.18.1",
   "type": "module",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-onlyBuiltDependencies:
-  - "@launchql/protobufjs"
-  - esbuild
-  - libpg-query
+allowBuilds:
+  "@launchql/protobufjs": true
+  esbuild: true
+  libpg-query: true
 # pnpm 11 makes strictDepBuilds true by default; we opt out so CI does not
 # fail when a transitive dependency adds a new build script. The packages we
 # actually need built are listed above; anything else is intentionally not


### PR DESCRIPTION
## Summary
- Bump `packageManager` from `pnpm@10.33.4` to `pnpm@11.1.2`.
- `pnpm-workspace.yaml` already has `strictDepBuilds: false`, so the pnpm 11 default change is already opted out.

## Test plan
- [x] `pnpm test:all` passes locally with pnpm 11
- [x] `pnpm check` in `site/` passes locally with pnpm 11