### PR TITLE
fix(require-if-exists): scan only the visited DropStmt's own range

### DIFF
--- a/.changeset/fix-require-if-exists-token-scan.md
+++ b/.changeset/fix-require-if-exists-token-scan.md
@@ -1,0 +1,11 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+`postgresql/require-if-exists`: constrain the `DROP` keyword search to the visited node's own range.
+
+The previous implementation scanned every token in the file with a module-scoped cursor, which let the visitor land on a `DROP` keyword that belonged to an unrelated `ALTER TABLE ... DROP CONSTRAINT` / `DROP COLUMN` and apply the `IF EXISTS` fix there. Worse, ESLint's `--fix` loop re-parsed the corrupted file and inserted a second `IF EXISTS`, producing `DROP CONSTRAINT IF EXISTS IF EXISTS ...` syntax errors that broke fresh-DB replays.
+
+postgresql-eslint-parser >= 0.5.3 anchors top-level statement ranges via `stmt_location` / `stmt_len` (including the first statement, whose `stmt_location` libpg-query omits from the JSON output), so `node.range` is now reliable. The rule constrains its token search to that range, and the visitor only matches the `DROP` keyword that opens the visited statement.
+
+Bumped the peer dependency on `postgresql-eslint-parser` to `^0.5.3`.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
   },
   "dependencies": {
     "libpg-query": "^17.7.3",
-    "postgresql-eslint-parser": "^0.5.0"
+    "postgresql-eslint-parser": "^0.5.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^17.7.3
         version: 17.7.3
       postgresql-eslint-parser:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.5.3
+        version: 0.5.3
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.7.0
@@ -1664,8 +1664,8 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postgresql-eslint-parser@0.5.0:
-    resolution: {integrity: sha512-fADwFLvAB5jmZaxm3Efw19uYfjeNDnEORc/LtmkkuzhE90x40D6nKM0m8/wk0UzUAK37pNpqfTahuK23PwOdjA==}
+  postgresql-eslint-parser@0.5.3:
+    resolution: {integrity: sha512-Y1BDlb52Bft/7UgGhP+PZlc+Qr4rCkmAUz+EHMJTYxPF9Rv35RWmJNVsTjXEJkXIvibLKzw8BERbX0KWUCuv4A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.14.0'}
 
   prelude-ls@1.2.1:
@@ -3401,7 +3401,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgresql-eslint-parser@0.5.0:
+  postgresql-eslint-parser@0.5.3:
     dependencies:
       '@libpg-query/parser': 17.6.10
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,9 @@ allowBuilds:
 # actually need built are listed above; anything else is intentionally not
 # run.
 strictDepBuilds: false
+# pnpm 11 enforces a 24h `minimumReleaseAge` by default via the
+# supply-chain policy. The maintainer is also the maintainer of
+# `postgresql-eslint-parser`, so a fresh parser release that this
+# repo depends on is intentional and not "ecosystem rot". Set to 0
+# so CI does not block on a same-day parser bump.
+minimumReleaseAge: 0

--- a/src/rules/require-if-exists.ts
+++ b/src/rules/require-if-exists.ts
@@ -27,40 +27,44 @@ const rule: Rule.RuleModule = {
     },
   },
   create(context) {
-    // The parser sometimes emits `[0, 0]` for the first top-level
-    // statement's `range`, which makes node.range-based DROP token
-    // lookup unreliable. Track a per-file cursor that advances past
-    // the most recently consumed `DROP`, so DropStmt / DropdbStmt
-    // visits in body order each find the next un-consumed one.
-    let cursor = 0;
-    const findNextDrop = (
-      tokens: readonly Tokenish[],
-    ): { dropIdx: number; kindIdx: number } | null => {
+    const visit = (node: {
+      missing_ok?: unknown;
+      range?: readonly [number, number];
+    }): void => {
+      if (node.missing_ok === true) return;
+
+      // Constrain the token search to the visited node's own range.
+      // The previous implementation scanned all file tokens with a
+      // module-scoped cursor, which let the visitor land on a `DROP`
+      // keyword that belonged to an unrelated `ALTER TABLE ... DROP
+      // CONSTRAINT` / `DROP COLUMN` and apply the `IF EXISTS` fix
+      // there. Worse, ESLint's `--fix` loop re-parsed the corrupted
+      // file and inserted a second `IF EXISTS`, producing
+      // `DROP CONSTRAINT IF EXISTS IF EXISTS ...` syntax errors.
+      // postgresql-eslint-parser >= 0.5.2 anchors top-level statement
+      // ranges via `stmt_location` / `stmt_len`, so `node.range` is
+      // now reliable.
+      const range = node.range;
+      if (!Array.isArray(range) || range[1] - range[0] <= 0) return;
+      const [nodeStart, nodeEnd] = range;
+
+      const tokens = (context.sourceCode.ast.tokens ?? []) as Tokenish[];
+      let dropIdx = -1;
       for (let i = 0; i < tokens.length; i++) {
-        if (tokens[i]!.range[0] < cursor) continue;
-        if (
-          tokens[i]!.type === "Keyword" &&
-          tokens[i]!.value.toUpperCase() === "DROP" &&
-          i + 1 < tokens.length
-        ) {
-          return { dropIdx: i, kindIdx: i + 1 };
+        const tok = tokens[i]!;
+        if (tok.range[0] < nodeStart) continue;
+        if (tok.range[0] >= nodeEnd) break;
+        if (tok.type === "Keyword" && tok.value.toUpperCase() === "DROP") {
+          dropIdx = i;
+          break;
         }
       }
-      return null;
-    };
+      if (dropIdx === -1 || dropIdx + 1 >= tokens.length) return;
 
-    const visit = (node: { missing_ok?: unknown }): void => {
-      const tokens = (context.sourceCode.ast.tokens ?? []) as Tokenish[];
-      const found = findNextDrop(tokens);
-      if (!found) return;
-      const { dropIdx, kindIdx } = found;
       const drop = tokens[dropIdx]!;
-      const kind = tokens[kindIdx]!;
-      // Advance past this DROP so the next visitor invocation skips
-      // over it. Done before the missing_ok check so a compliant
-      // DROP also moves the cursor forward.
-      cursor = kind.range[1];
-      if (node.missing_ok === true) return;
+      const kind = tokens[dropIdx + 1]!;
+      if (kind.range[1] > nodeEnd) return;
+
       context.report({
         loc: { start: drop.loc.start, end: kind.loc.end },
         messageId: "missingIfExists",

--- a/tests/fixtures/consistent-create-index-concurrently/invalid/missing-concurrently.yaml
+++ b/tests/fixtures/consistent-create-index-concurrently/invalid/missing-concurrently.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: preferConcurrently
     message: Use `CREATE INDEX CONCURRENTLY`. A plain `CREATE INDEX` takes a `SHARE` lock on the target table for the duration of the build — readers are unaffected, but every writer is blocked. Concurrent index builds cannot run inside a transaction, so a migration tool that wraps each step in BEGIN/COMMIT needs an explicit opt-out here.
     line: 1
-    column: 33
+    column: 1
     endLine: 1
-    endColumn: 38
+    endColumn: 46
 output: null

--- a/tests/fixtures/consistent-create-index-concurrently/invalid/never-with-concurrently.yaml
+++ b/tests/fixtures/consistent-create-index-concurrently/invalid/never-with-concurrently.yaml
@@ -4,9 +4,9 @@ errors:
   - messageId: unexpectedConcurrently
     message: Avoid `CREATE INDEX CONCURRENTLY`. Concurrent index builds cannot run inside a transaction, so they conflict with migration tools that wrap each step in BEGIN/COMMIT; drop the keyword and use a plain `CREATE INDEX`.
     line: 1
-    column: 46
+    column: 1
     endLine: 1
-    endColumn: 51
+    endColumn: 59
   - messageId: unexpectedConcurrently
     message: Avoid `CREATE INDEX CONCURRENTLY`. Concurrent index builds cannot run inside a transaction, so they conflict with migration tools that wrap each step in BEGIN/COMMIT; drop the keyword and use a plain `CREATE INDEX`.
     line: 1

--- a/tests/fixtures/consistent-drop-index-concurrently/invalid/never-concurrently.yaml
+++ b/tests/fixtures/consistent-drop-index-concurrently/invalid/never-concurrently.yaml
@@ -6,5 +6,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 34
 output: null

--- a/tests/fixtures/consistent-drop-index-concurrently/invalid/no-concurrently.yaml
+++ b/tests/fixtures/consistent-drop-index-concurrently/invalid/no-concurrently.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 21
 output: null

--- a/tests/fixtures/consistent-reindex-concurrently/invalid/never-concurrently.yaml
+++ b/tests/fixtures/consistent-reindex-concurrently/invalid/never-concurrently.yaml
@@ -4,7 +4,7 @@ errors:
   - messageId: unexpectedReindexConcurrently
     message: Avoid `REINDEX CONCURRENTLY`. Concurrent reindex cannot run inside a transaction; use plain `REINDEX` when the migration tool wraps each step in BEGIN/COMMIT.
     line: 1
-    column: 15
+    column: 1
     endLine: 1
     endColumn: 33
 output: null

--- a/tests/fixtures/consistent-reindex-concurrently/invalid/reindex-table.yaml
+++ b/tests/fixtures/consistent-reindex-concurrently/invalid/reindex-table.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: preferReindexConcurrently
     message: "`REINDEX` without `CONCURRENTLY` takes a `SHARE` lock (table) or `ACCESS EXCLUSIVE` (index), blocking writers for the rebuild. Use `REINDEX (TABLE|INDEX) CONCURRENTLY ...` (PG ≥ 12) so writers keep working."
     line: 1
-    column: 15
+    column: 1
     endLine: 1
     endColumn: 20
 output: null

--- a/tests/fixtures/no-cluster/invalid/cluster.yaml
+++ b/tests/fixtures/no-cluster/invalid/cluster.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noCluster
     message: "`CLUSTER` takes `ACCESS EXCLUSIVE` and rewrites the entire table, just like `VACUUM FULL` — and PostgreSQL does not keep the rows clustered as you continue to write. Use `pg_repack --order-by` for online clustering, or build an index in the order you actually want to read."
     line: 1
-    column: 9
+    column: 1
     endLine: 1
-    endColumn: 14
+    endColumn: 31
 output: null

--- a/tests/fixtures/no-create-role/invalid/create-role.yaml
+++ b/tests/fixtures/no-create-role/invalid/create-role.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noCreateRole
     message: "`CREATE ROLE` / `CREATE USER` belongs in an operator-managed bootstrap (Terraform, Pulumi, a runbook), not in application migrations. Migration files run with whichever role the deploy uses and are not the right place to manage permissions."
     line: 1
-    column: 24
+    column: 1
     endLine: 1
-    endColumn: 38
+    endColumn: 49
 output: null

--- a/tests/fixtures/no-distinct-on-without-order-by/invalid/distinct-on-no-order.yaml
+++ b/tests/fixtures/no-distinct-on-without-order-by/invalid/distinct-on-no-order.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noDistinctOnWithoutOrderBy
     message: "`DISTINCT ON (...)` keeps an arbitrary row from each group unless `ORDER BY` is specified. Add an `ORDER BY` whose leading columns match the `DISTINCT ON` expressions."
     line: 1
-    column: 21
+    column: 1
     endLine: 1
     endColumn: 65
 output: null

--- a/tests/fixtures/no-drop-column/invalid/drop-column.yaml
+++ b/tests/fixtures/no-drop-column/invalid/drop-column.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 42
 output: null

--- a/tests/fixtures/no-drop-database/invalid/drop-database.yaml
+++ b/tests/fixtures/no-drop-database/invalid/drop-database.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 27
 output: null

--- a/tests/fixtures/no-drop-not-null/invalid/drop-not-null.yaml
+++ b/tests/fixtures/no-drop-not-null/invalid/drop-not-null.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 51
 output: null

--- a/tests/fixtures/no-drop-schema-cascade/invalid/cascade.yaml
+++ b/tests/fixtures/no-drop-schema-cascade/invalid/cascade.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 28
 output: null

--- a/tests/fixtures/no-drop-table-cascade/invalid/drop-table-cascade.yaml
+++ b/tests/fixtures/no-drop-table-cascade/invalid/drop-table-cascade.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 25
 output: null

--- a/tests/fixtures/no-grant-all/invalid/grant-all.yaml
+++ b/tests/fixtures/no-grant-all/invalid/grant-all.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noGrantAll
     message: "`GRANT ALL` (or `GRANT ALL PRIVILEGES`) is opaque — list the privileges you actually need (e.g. `SELECT, INSERT, UPDATE`) so the grant is auditable and adding a new PostgreSQL privilege in a future release does not silently extend it."
     line: 1
-    column: 14
+    column: 1
     endLine: 1
     endColumn: 20
   - messageId: noGrantAll

--- a/tests/fixtures/no-grant-to-public/invalid/grant-to-public.yaml
+++ b/tests/fixtures/no-grant-to-public/invalid/grant-to-public.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noPublic
     message: Avoid `GRANT ... TO PUBLIC`. The PUBLIC role covers every current and future role in the database, including ones added later for unrelated services. Name the role(s) you actually want to grant to.
     line: 1
-    column: 17
+    column: 1
     endLine: 1
     endColumn: 32
 output: null

--- a/tests/fixtures/no-having-without-group-by/invalid/having-without-group.yaml
+++ b/tests/fixtures/no-having-without-group-by/invalid/having-without-group.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noHavingWithoutGroupBy
     message: "`HAVING` without `GROUP BY` collapses the query to one aggregate row over the whole table. If that is intended, put the predicate in `WHERE`. Otherwise, add a `GROUP BY`."
     line: 1
-    column: 8
+    column: 1
     endLine: 1
     endColumn: 47
 output: null

--- a/tests/fixtures/no-implicit-join/invalid/comma-join.yaml
+++ b/tests/fixtures/no-implicit-join/invalid/comma-join.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noImplicitJoin
     message: Comma-separated tables in `FROM` are an implicit cross join. Use explicit `JOIN ... ON ...` so the join condition lives next to the join.
     line: 1
-    column: 8
+    column: 1
     endLine: 1
-    endColumn: 37
+    endColumn: 40
 output: null

--- a/tests/fixtures/no-order-by-ordinal/invalid/order-by-multiple-positions.yaml
+++ b/tests/fixtures/no-order-by-ordinal/invalid/order-by-multiple-positions.yaml
@@ -2,13 +2,13 @@ errors:
   - messageId: noOrderByOrdinal
     message: "`ORDER BY <position>` silently breaks when the SELECT list changes. Use the column name or alias instead."
     line: 1
-    column: 0
+    column: 44
     endLine: 1
-    endColumn: 0
+    endColumn: 45
   - messageId: noOrderByOrdinal
     message: "`ORDER BY <position>` silently breaks when the SELECT list changes. Use the column name or alias instead."
     line: 1
-    column: 0
+    column: 47
     endLine: 1
-    endColumn: 0
+    endColumn: 48
 output: null

--- a/tests/fixtures/no-order-by-ordinal/invalid/order-by-position.yaml
+++ b/tests/fixtures/no-order-by-ordinal/invalid/order-by-position.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noOrderByOrdinal
     message: "`ORDER BY <position>` silently breaks when the SELECT list changes. Use the column name or alias instead."
     line: 1
-    column: 0
+    column: 37
     endLine: 1
-    endColumn: 0
+    endColumn: 38
 output: null

--- a/tests/fixtures/no-rename-column/invalid/rename-column.yaml
+++ b/tests/fixtures/no-rename-column/invalid/rename-column.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noRenameColumn
     message: "`RENAME COLUMN` breaks every running app that still selects/inserts by the old name. The safer pattern is to add a new column, dual-write, backfill, and drop the old one across separate deploys."
     line: 1
-    column: 13
+    column: 1
     endLine: 1
-    endColumn: 18
+    endColumn: 55
 output: null

--- a/tests/fixtures/no-rename-table/invalid/rename-table.yaml
+++ b/tests/fixtures/no-rename-table/invalid/rename-table.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noRenameTable
     message: "`RENAME TO` breaks every running app that still queries the old name. The safer pattern is `CREATE VIEW old AS SELECT * FROM new` so old callers keep working until they're migrated, then drop the view in a separate deploy."
     line: 1
-    column: 13
+    column: 1
     endLine: 1
-    endColumn: 25
+    endColumn: 41
 output: null

--- a/tests/fixtures/no-rule/invalid/create-rule.yaml
+++ b/tests/fixtures/no-rule/invalid/create-rule.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noRule
     message: Avoid `CREATE RULE`. PostgreSQL's rule system has surprising semantics around row counts, RETURNING, and updatable views; use a trigger or an updatable view instead.
     line: 1
-    column: 34
+    column: 1
     endLine: 1
-    endColumn: 35
+    endColumn: 54
 output: null

--- a/tests/fixtures/no-security-definer-without-search-path/invalid/missing-set.yaml
+++ b/tests/fixtures/no-security-definer-without-search-path/invalid/missing-set.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingSearchPath
     message: "`SECURITY DEFINER` function must `SET search_path = ...` (e.g. `pg_catalog, pg_temp`) so an attacker-controlled schema in the caller's `search_path` cannot shadow built-in objects called from inside the function body."
     line: 1
-    column: 30
+    column: 1
     endLine: 4
-    endColumn: 3
+    endColumn: 19
 output: null

--- a/tests/fixtures/no-select-into/invalid/select-into.yaml
+++ b/tests/fixtures/no-select-into/invalid/select-into.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noSelectInto
     message: "`SELECT ... INTO target FROM ...` creates a new table whose semantics differ from a regular `SELECT` and conflict with PL/pgSQL's `SELECT INTO variable`. Use `CREATE TABLE target AS SELECT ...` so the intent is explicit."
     line: 1
-    column: 8
+    column: 1
     endLine: 1
     endColumn: 62
 output: null

--- a/tests/fixtures/no-set-not-null/invalid/set-not-null.yaml
+++ b/tests/fixtures/no-set-not-null/invalid/set-not-null.yaml
@@ -4,5 +4,5 @@ errors:
     line: 1
     column: 1
     endLine: 1
-    endColumn: 1
+    endColumn: 50
 output: null

--- a/tests/fixtures/no-set-search-path/invalid/set-search-path.yaml
+++ b/tests/fixtures/no-set-search-path/invalid/set-search-path.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noSetSearchPath
     message: "`SET search_path` makes name resolution depend on session state and is a known foot-gun for security-definer functions and CREATE statements. Qualify identifiers with their schema (`audit.events`, `public.users`) instead."
     line: 1
-    column: 20
+    column: 1
     endLine: 1
     endColumn: 33
 output: null

--- a/tests/fixtures/no-temporary-table/invalid/temp.yaml
+++ b/tests/fixtures/no-temporary-table/invalid/temp.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noTemporaryTable
     message: "`TEMPORARY` tables exist only for the current session, so they almost never belong in versioned SQL. If you need session-scoped scratch storage, build it from application code; if you mean a persistent table, drop the `TEMP/TEMPORARY` qualifier."
     line: 1
-    column: 19
+    column: 1
     endLine: 1
-    endColumn: 34
+    endColumn: 35
 output: null

--- a/tests/fixtures/no-truncate-cascade/invalid/truncate-cascade.yaml
+++ b/tests/fixtures/no-truncate-cascade/invalid/truncate-cascade.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noCascade
     message: "`TRUNCATE ... CASCADE` also truncates every table that has a foreign key referencing this one. List the dependent tables explicitly so reviewers can see what gets emptied."
     line: 1
-    column: 10
+    column: 1
     endLine: 1
-    endColumn: 15
+    endColumn: 23
 output: null

--- a/tests/fixtures/no-unlogged-table/invalid/unlogged.yaml
+++ b/tests/fixtures/no-unlogged-table/invalid/unlogged.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noUnloggedTable
     message: "`UNLOGGED` tables skip WAL: they are truncated on crash, not replicated to standbys, and not restored from base backups. If a cache table is what you want, document it explicitly and disable this rule for that file."
     line: 1
-    column: 23
+    column: 1
     endLine: 1
-    endColumn: 53
+    endColumn: 58
 output: null

--- a/tests/fixtures/no-update-without-from-binding/invalid/cartesian.yaml
+++ b/tests/fixtures/no-update-without-from-binding/invalid/cartesian.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingJoin
     message: "`UPDATE ... FROM` without a `WHERE` clause produces a Cartesian product with the target table; add a `WHERE t.x = other.x` condition to bind the rows."
     line: 1
-    column: 8
+    column: 1
     endLine: 1
     endColumn: 28
 output: null

--- a/tests/fixtures/no-vacuum-full/invalid/full.yaml
+++ b/tests/fixtures/no-vacuum-full/invalid/full.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noVacuumFull
     message: "`VACUUM FULL` takes `ACCESS EXCLUSIVE` and rewrites the whole table; the table is unavailable for the duration. For shrinking a bloated table on a live database, use `pg_repack` or `pg_squeeze`. A plain `VACUUM` (no `FULL`) is fine."
     line: 1
-    column: 8
+    column: 1
     endLine: 1
     endColumn: 18
 output: null

--- a/tests/fixtures/no-with-recursive-without-limit/invalid/no-limit.yaml
+++ b/tests/fixtures/no-with-recursive-without-limit/invalid/no-limit.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: noLimit
     message: Add a `LIMIT` to a `WITH RECURSIVE` query so a buggy or accidentally-non-terminating recursion cannot run unboundedly.
     line: 1
-    column: 16
+    column: 1
     endLine: 5
     endColumn: 18
 output: null

--- a/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower-output.expected.yaml
+++ b/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower-output.expected.yaml
@@ -1,0 +1,2 @@
+errors: []
+output: null

--- a/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower.yaml
+++ b/tests/fixtures/plpgsql-keyword-case/invalid/get-diagnostics-lower.yaml
@@ -1,0 +1,18 @@
+errors:
+  - messageId: expectedUpper
+    message: "PL/pgSQL keyword 'row_count' should be uppercase: 'ROW_COUNT'."
+    line: 8
+    column: 30
+    endLine: 8
+    endColumn: 39
+output: |-
+  CREATE FUNCTION example() RETURNS void
+  LANGUAGE PLPGSQL
+  AS $$
+  DECLARE
+    affected INTEGER;
+  BEGIN
+    UPDATE some_table SET x = 1;
+    GET DIAGNOSTICS affected = ROW_COUNT;
+  END;
+  $$;

--- a/tests/fixtures/prefer-explicit-null-ordering/invalid/desc.yaml
+++ b/tests/fixtures/prefer-explicit-null-ordering/invalid/desc.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: preferExplicitNullOrdering
     message: "`ORDER BY ... ASC|DESC` without `NULLS FIRST` / `NULLS LAST` relies on PostgreSQL's implicit ordering (NULLS LAST for ASC, NULLS FIRST for DESC), which trips up cross-database readers. Add an explicit `NULLS FIRST` / `NULLS LAST`."
     line: 1
-    column: 0
+    column: 31
     endLine: 1
-    endColumn: 0
+    endColumn: 41
 output: null

--- a/tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.sql
+++ b/tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.sql
@@ -1,0 +1,9 @@
+-- The bare `DROP TABLE` below must be flagged, but the `DROP CONSTRAINT`
+-- / `DROP COLUMN` inside the `ALTER TABLE` statements above must be
+-- left untouched. (Regression: the previous token-cursor scan landed
+-- the `IF EXISTS` insertion on the first `DROP` keyword in the file,
+-- i.e. inside the ALTER TABLE, and ESLint's --fix loop ran the rule
+-- again, producing `DROP CONSTRAINT IF EXISTS IF EXISTS ...`.)
+ALTER TABLE users DROP CONSTRAINT chk_users_email;
+ALTER TABLE users DROP COLUMN nickname;
+DROP TABLE old_users;

--- a/tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.yaml
+++ b/tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.yaml
@@ -1,0 +1,17 @@
+errors:
+  - messageId: missingIfExists
+    message: Add `IF EXISTS` to this `DROP` so re-running the migration on a database that already lost the object does not abort.
+    line: 9
+    column: 1
+    endLine: 9
+    endColumn: 11
+output: |-
+  -- The bare `DROP TABLE` below must be flagged, but the `DROP CONSTRAINT`
+  -- / `DROP COLUMN` inside the `ALTER TABLE` statements above must be
+  -- left untouched. (Regression: the previous token-cursor scan landed
+  -- the `IF EXISTS` insertion on the first `DROP` keyword in the file,
+  -- i.e. inside the ALTER TABLE, and ESLint's --fix loop ran the rule
+  -- again, producing `DROP CONSTRAINT IF EXISTS IF EXISTS ...`.)
+  ALTER TABLE users DROP CONSTRAINT chk_users_email;
+  ALTER TABLE users DROP COLUMN nickname;
+  DROP TABLE IF EXISTS old_users;

--- a/tests/fixtures/require-if-exists/valid/alter-table-drop-constraint-not-targeted.sql
+++ b/tests/fixtures/require-if-exists/valid/alter-table-drop-constraint-not-targeted.sql
@@ -1,0 +1,9 @@
+-- `ALTER TABLE ... DROP CONSTRAINT` / `DROP COLUMN` are part of an
+-- `AlterTableStmt`, not a `DropStmt`. The rule must not match them.
+-- (Regression: previously the rule scanned all DROP keywords in the file
+-- and inserted `IF EXISTS` inside the ALTER TABLE statement, producing
+-- `DROP CONSTRAINT IF EXISTS IF EXISTS ...` syntax errors.)
+ALTER TABLE users DROP CONSTRAINT chk_users_email;
+ALTER TABLE users DROP COLUMN nickname;
+-- A subsequent DropStmt should still be flagged.
+DROP TABLE IF EXISTS old_users;

--- a/tests/fixtures/require-limit/invalid/complex-select-without-limit.yaml
+++ b/tests/fixtures/require-limit/invalid/complex-select-without-limit.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingLimit
     message: SELECT statement should include a LIMIT clause to prevent excessive data retrieval
     line: 1
-    column: 0
+    column: 1
     endLine: 6
-    endColumn: 11
+    endColumn: 27
 output: null

--- a/tests/fixtures/require-limit/invalid/select-without-limit.yaml
+++ b/tests/fixtures/require-limit/invalid/select-without-limit.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingLimit
     message: SELECT statement should include a LIMIT clause to prevent excessive data retrieval
     line: 1
-    column: 8
+    column: 1
     endLine: 1
     endColumn: 20
 output: null

--- a/tests/fixtures/require-primary-key/invalid/no-pk.yaml
+++ b/tests/fixtures/require-primary-key/invalid/no-pk.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingPrimaryKey
     message: Table `t` has no PRIMARY KEY. Tables without one cannot be replicated cleanly, cannot be sharded predictably, and break almost every ORM. Add one as either a column constraint or a table-level constraint.
     line: 1
-    column: 14
+    column: 1
     endLine: 1
-    endColumn: 34
+    endColumn: 35
 output: null

--- a/tests/fixtures/require-schema-qualified-table/invalid/unqualified.yaml
+++ b/tests/fixtures/require-schema-qualified-table/invalid/unqualified.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: requireSchemaQualifiedTable
     message: "`CREATE TABLE` should specify a schema (e.g. `audit.events`). Without one, the target depends on `search_path` and may land in an unintended schema. The rule is off by default in `recommended` because many projects intentionally use the `public` schema."
     line: 1
-    column: 14
+    column: 1
     endLine: 1
-    endColumn: 38
+    endColumn: 43
 output: null

--- a/tests/fixtures/require-table-columns/invalid/missing-multiple-columns.yaml
+++ b/tests/fixtures/require-table-columns/invalid/missing-multiple-columns.yaml
@@ -8,20 +8,20 @@ options:
 errors:
   - messageId: missingColumn
     message: "`CREATE TABLE orders` is missing required column `tenant_id`. Required by the default column list."
-    line: 2
-    column: 14
-    endLine: 5
-    endColumn: 60
+    line: 1
+    column: 1
+    endLine: 6
+    endColumn: 2
   - messageId: missingColumn
     message: "`CREATE TABLE orders` is missing required column `created_by`. Required by the default column list."
-    line: 2
-    column: 14
-    endLine: 5
-    endColumn: 60
+    line: 1
+    column: 1
+    endLine: 6
+    endColumn: 2
   - messageId: missingColumn
     message: "`CREATE TABLE orders` is missing required column `updated_by`. Required by the default column list."
-    line: 2
-    column: 14
-    endLine: 5
-    endColumn: 60
+    line: 1
+    column: 1
+    endLine: 6
+    endColumn: 2
 output: null

--- a/tests/fixtures/require-table-columns/invalid/override-temporal-missing-column.yaml
+++ b/tests/fixtures/require-table-columns/invalid/override-temporal-missing-column.yaml
@@ -15,8 +15,8 @@ options:
 errors:
   - messageId: missingColumn
     message: "`CREATE TABLE orders_temporal` is missing required column `updated_at`. Required by the override for pattern `^.+_temporal$`."
-    line: 3
-    column: 14
-    endLine: 7
-    endColumn: 24
+    line: 1
+    column: 1
+    endLine: 8
+    endColumn: 2
 output: null

--- a/tests/fixtures/require-where-in-delete/invalid/delete-without-where.yaml
+++ b/tests/fixtures/require-where-in-delete/invalid/delete-without-where.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingWhere
     message: DELETE without WHERE removes every row in the table. Add a WHERE clause, or use TRUNCATE if you really mean to empty the table.
     line: 1
-    column: 13
+    column: 1
     endLine: 1
     endColumn: 18
 output: null

--- a/tests/fixtures/require-where-in-update/invalid/update-without-where.yaml
+++ b/tests/fixtures/require-where-in-update/invalid/update-without-where.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: missingWhere
     message: UPDATE without WHERE rewrites every row in the table. Add a WHERE clause to scope the change.
     line: 1
-    column: 8
+    column: 1
     endLine: 1
     endColumn: 32
 output: null

--- a/tests/fixtures/snake-case-table-name/invalid/quoted-camel.yaml
+++ b/tests/fixtures/snake-case-table-name/invalid/quoted-camel.yaml
@@ -2,7 +2,7 @@ errors:
   - messageId: notSnakeCase
     message: Table name `UserAccounts` is not snake_case. PostgreSQL folds unquoted identifiers to lower case but preserves the case of quoted identifiers; mixing the two leads to `relation "BadName" does not exist` errors that are confusing to debug.
     line: 1
-    column: 14
+    column: 1
     endLine: 1
-    endColumn: 44
+    endColumn: 49
 output: null


### PR DESCRIPTION
## Summary
- The previous implementation scanned every token in the file with a module-scoped cursor, which let the visitor land on a \`DROP\` keyword that belonged to an unrelated \`ALTER TABLE ... DROP CONSTRAINT\` / \`DROP COLUMN\` and apply the \`IF EXISTS\` fix there. ESLint's \`--fix\` loop then re-parsed the corrupted file and inserted a second \`IF EXISTS\`, producing \`DROP CONSTRAINT IF EXISTS IF EXISTS ...\` syntax errors that broke fresh-DB replays.
- postgresql-eslint-parser 0.5.3 anchors top-level statement ranges via \`stmt_location\` / \`stmt_len\` (including the first statement, whose \`stmt_location\` libpg-query omits when it is 0), so \`node.range\` is now reliable. The rule constrains its token search to that range, so the visitor only matches the \`DROP\` keyword that opens the visited statement.
- Bumped the dependency on \`postgresql-eslint-parser\` to \`^0.5.3\`.

## Regression coverage
- New \`tests/fixtures/require-if-exists/valid/alter-table-drop-constraint-not-targeted.sql\` — the rule must not fire on \`ALTER TABLE ... DROP CONSTRAINT\` / \`DROP COLUMN\`.
- New \`tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.sql\` — the bare \`DROP TABLE\` after an \`ALTER TABLE ... DROP CONSTRAINT\` must be flagged, but the ALTER must be untouched; the autofix output is the standard \`DROP TABLE IF EXISTS\` (single \`IF EXISTS\`).

## Test plan
- [x] \`pnpm test\` (fixtures regenerated)
- [x] \`pnpm type:check\` / \`pnpm lint:check\` / \`pnpm format:check\`