### PR TITLE
fix(consistent-as-for-column-alias): do not corrupt compound value exprs

### DIFF
--- a/.changeset/fix-consistent-as-for-column-alias-compound-exprs.md
+++ b/.changeset/fix-consistent-as-for-column-alias-compound-exprs.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+`postgresql/consistent-as-for-column-alias`: stop corrupting compound value expressions when adding `AS`.
+
+For values like `expr::type`, `table.col`, or `CASE WHEN … END`, the parser-reported `range[1]` for the value sometimes stops in the middle of the expression (e.g. between `::` and the type name, or right after the first dotted segment). The rule used to look at the token immediately after that range and, when it was not `AS`, insert `AS ` there — corrupting the SQL into `()::AS ulid …`, `uAS .col`, `CASE AS WHEN …`. ESLint's `--fix` loop then re-parsed and applied other fixes on top of the broken SQL.
+
+The fix only inserts `AS` when the token immediately after the value range actually matches the alias identifier (`target.name`, comparing the raw token text and the unquoted form of a double-quoted identifier). When the parser range is too narrow and the next token is part of the value expression, the rule now skips instead of corrupting the source. The trade-off is a false negative on compound expressions that genuinely omit `AS`, which is strictly safer than the previous false fix.

--- a/src/rules/consistent-as-for-column-alias.ts
+++ b/src/rules/consistent-as-for-column-alias.ts
@@ -33,6 +33,18 @@ const rule: Rule.RuleModule = {
   create(context) {
     const option = (context.options[0] ?? {}) as { style?: Style };
     const style: Style = option.style ?? DEFAULT_STYLE;
+
+    // Strip surrounding double quotes from an identifier token's literal
+    // text so we can compare it against `target.name` (which holds the
+    // unquoted identifier).
+    const tokenIdentifierText = (token: AST.Token): string => {
+      const value = token.value;
+      if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+        return value.slice(1, -1);
+      }
+      return value;
+    };
+
     return {
       // Only flag aliases that appear in SELECT's targetList. The same
       // ResTarget node type is used for INSERT column lists and UPDATE
@@ -59,11 +71,22 @@ const rule: Rule.RuleModule = {
           if (!next || nextIndex < 0) continue;
           const hasAs =
             next.type === "Keyword" && next.value.toUpperCase() === "AS";
+
           if (style === "always" && !hasAs) {
+            // Defense against parser ranges that stop in the middle of a
+            // compound expression (TypeCast `expr::type`, dotted ColumnRef
+            // `t.col`, CASE expressions, etc.). If `valEnd` lands inside
+            // the value, the next token is part of the expression — not
+            // the alias — so we must not insert `AS` there. Confirm the
+            // next token is the alias identifier before reporting.
+            const aliasName = target.name;
+            const looksLikeAliasIdentifier =
+              tokenIdentifierText(next) === aliasName;
+            if (!looksLikeAliasIdentifier) continue;
             context.report({
               loc: next.loc,
               messageId: "preferAs",
-              data: { alias: target.name },
+              data: { alias: aliasName },
               fix: (fixer) => fixer.insertTextBeforeRange(next!.range, "AS "),
             });
             continue;

--- a/tests/fixtures/consistent-as-for-column-alias/invalid/compound-expression-without-as.sql
+++ b/tests/fixtures/consistent-as-for-column-alias/invalid/compound-expression-without-as.sql
@@ -1,0 +1,9 @@
+-- When the alias is omitted on a TypeCast value the rule's old logic
+-- would have corrupted `()::ulid id` into `()::AS ulid id` (parser range
+-- ends mid-cast). The defensive check requires the next token to match
+-- the alias name before inserting `AS`, so we only flag the bare ones
+-- whose next token actually is the alias.
+SELECT
+  COUNT(*) total,
+  id user_id
+FROM users;

--- a/tests/fixtures/consistent-as-for-column-alias/invalid/compound-expression-without-as.yaml
+++ b/tests/fixtures/consistent-as-for-column-alias/invalid/compound-expression-without-as.yaml
@@ -1,0 +1,17 @@
+errors:
+  - messageId: preferAs
+    message: Use `AS` before the column alias `user_id`.
+    line: 8
+    column: 6
+    endLine: 8
+    endColumn: 13
+output: |-
+  -- When the alias is omitted on a TypeCast value the rule's old logic
+  -- would have corrupted `()::ulid id` into `()::AS ulid id` (parser range
+  -- ends mid-cast). The defensive check requires the next token to match
+  -- the alias name before inserting `AS`, so we only flag the bare ones
+  -- whose next token actually is the alias.
+  SELECT
+    COUNT(*) total,
+    id AS user_id
+  FROM users;

--- a/tests/fixtures/consistent-as-for-column-alias/valid/compound-expression-with-as.sql
+++ b/tests/fixtures/consistent-as-for-column-alias/valid/compound-expression-with-as.sql
@@ -1,0 +1,13 @@
+-- TypeCast (`expr::type`), dotted ColumnRef (`t.col`) and CASE expressions
+-- expose parser ranges that stop in the middle of the value expression
+-- (e.g. on `::` between the inner expr and the type name, or on the
+-- first dotted segment). The rule must still see `AS` as present.
+-- (Regression: the rule used to look at the token immediately after the
+-- parser-reported value range and, when that token was `ulid` / `.` /
+-- `WHEN` instead of `AS`, it inserted `AS` in the middle of the
+-- expression, producing `()::AS ulid`, `uAS .col`, `CASE AS WHEN ...`.)
+SELECT
+  generate_ulid_plv8()::ulid AS some_id,
+  u.user_id AS created_by,
+  CASE WHEN x = 1 THEN 'a' WHEN x = 2 THEN 'b' ELSE 'c' END AS label
+FROM users u;


### PR DESCRIPTION
## Summary
- For values like \`expr::type\`, \`table.col\`, or \`CASE WHEN ... END\`, the parser-reported \`range[1]\` for the value sometimes stops in the middle of the expression (between \`::\` and the type name, or after the first dotted segment, or after \`CASE\`). The rule used to look at the token immediately after that range and, when it was not \`AS\`, insert \`AS \` there — corrupting the SQL into \`()::AS ulid ...\`, \`uAS .col\`, \`CASE AS WHEN ...\`.
- ESLint's \`--fix\` loop then re-parsed and applied other fixes on top of the corrupted SQL.
- Only insert \`AS\` when the token immediately after the value range actually matches the alias identifier (\`target.name\`, comparing the raw token text and the unquoted form of a double-quoted identifier). When the parser range is too narrow and the next token is part of the value expression, the rule now skips instead of corrupting the source.

The trade-off is a false negative on compound expressions that genuinely omit \`AS\`, which is strictly safer than the previous false fix.

## Test plan
- [x] \`vitest run\` (fixtures regenerated; new \`compound-expression-with-as\` valid + \`compound-expression-without-as\` invalid cover the regression).
- [x] \`pnpm type:check\` / \`pnpm lint:check\` / \`pnpm format:check\`.