### PR TITLE
fix(consistent-create-or-replace): remove the autofix (semantics change)

### DIFF
--- a/.changeset/remove-consistent-create-or-replace-fixer.md
+++ b/.changeset/remove-consistent-create-or-replace-fixer.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+`postgresql/consistent-create-or-replace`: remove the autofix.
+
+Adding `OR REPLACE` turns a CREATE statement from "abort if the object already exists" into "silently overwrite the existing object"; removing it does the reverse. Both are runtime-semantics changes that depend on author intent — the maintenance migration that re-defines a function intentionally needs `OR REPLACE`, while the initial-creation migration intentionally does not. An ESLint autofixer must not make that choice on the author's behalf.
+
+The rule still reports the violation so authors can pick the right form by hand. The `fixable` metadata is removed, and the messages are unchanged.

--- a/src/rules/consistent-create-or-replace.ts
+++ b/src/rules/consistent-create-or-replace.ts
@@ -23,7 +23,10 @@ const rule: Rule.RuleModule = {
       category: "Best Practices",
       recommended: false,
     },
-    fixable: "code",
+    // No autofix on purpose. Adding `OR REPLACE` turns a guard
+    // ("error if object already exists") into an in-place overwrite;
+    // removing it does the reverse. Both are runtime-semantics
+    // changes that the linter must not make on the author's behalf.
     schema: [
       {
         type: "object",
@@ -85,39 +88,15 @@ const rule: Rule.RuleModule = {
           loc: create.loc,
           messageId: "preferOrReplace",
           data: { kind },
-          fix: (fixer) =>
-            fixer.insertTextAfterRange(create.range, " OR REPLACE"),
         });
         return;
       }
 
       if (style === "never" && hasOrReplace) {
-        // Locate the `OR` and `REPLACE` keywords that follow CREATE.
-        // We stay strict: the two keywords must be the immediate next
-        // two non-trivial tokens after CREATE. Otherwise we skip the
-        // fix (still report) to avoid mangling unexpected syntax.
-        const orIdx = found.createIdx + 1;
-        const replaceIdx = found.createIdx + 2;
-        const orTok = tokens[orIdx];
-        const replaceTok = tokens[replaceIdx];
-        // `OR` is a Keyword, but `REPLACE` is emitted as an Identifier
-        // by the upstream parser — match value, not just type.
-        const canFix =
-          orTok != null &&
-          orTok.value.toUpperCase() === "OR" &&
-          replaceTok != null &&
-          replaceTok.value.toUpperCase() === "REPLACE";
-        // Advance cursor past `OR REPLACE` so a later CREATE in the
-        // same file isn't tripped up by these tokens.
-        if (canFix) cursor = replaceTok!.range[1];
         context.report({
           loc: create.loc,
           messageId: "unexpectedOrReplace",
           data: { kind },
-          fix: canFix
-            ? (fixer) =>
-                fixer.removeRange([create.range[1], replaceTok!.range[1]])
-            : null,
         });
       }
     };

--- a/tests/fixtures/consistent-create-or-replace/invalid/missing-or-replace.yaml
+++ b/tests/fixtures/consistent-create-or-replace/invalid/missing-or-replace.yaml
@@ -17,7 +17,4 @@ errors:
     column: 1
     endLine: 3
     endColumn: 7
-output: |-
-  CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';
-  CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS '';
-  CREATE OR REPLACE VIEW v AS SELECT 1;
+output: null

--- a/tests/fixtures/consistent-create-or-replace/invalid/never-with-or-replace.yaml
+++ b/tests/fixtures/consistent-create-or-replace/invalid/never-with-or-replace.yaml
@@ -19,7 +19,4 @@ errors:
     column: 1
     endLine: 3
     endColumn: 7
-output: |-
-  CREATE FUNCTION fn() RETURNS void LANGUAGE SQL AS '';
-  CREATE PROCEDURE p() LANGUAGE SQL AS '';
-  CREATE VIEW v AS SELECT 1;
+output: null


### PR DESCRIPTION
## Summary
- Adding \`OR REPLACE\` turns \`CREATE\` from "abort if the object already exists" into "silently overwrite the existing object"; removing it does the reverse. Both are runtime-semantics changes — the maintenance migration that re-defines a function intentionally needs \`OR REPLACE\`, while the initial-creation migration intentionally does not.
- An ESLint autofixer must not make that choice on the author's behalf, so the \`fix:\` callbacks and the \`fixable\` metadata are dropped. The rule still reports the violation so authors can pick the right form by hand.
- Reported and discussed in [flyle-io/flyle-nexus#4897](https://github.com/flyle-io/flyle-nexus/pull/4897), where \`--fix\` silently stripped \`OR REPLACE\` from several maintenance migrations that re-define existing functions, so a fresh-DB replay aborted on \`already exists\`.

## Test plan
- [x] \`vitest run\` (existing fixtures updated to \`output: null\` for the two invalid cases; error reporting unchanged).
- [x] \`pnpm type:check\` / \`pnpm lint:check\` / \`pnpm format:check\`.