### PR TITLE
fix(require-if-exists): remove the autofix (semantics change)

### DIFF
--- a/.changeset/remove-require-if-exists-fixer.md
+++ b/.changeset/remove-require-if-exists-fixer.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+`postgresql/require-if-exists`: remove the autofix.
+
+Adding `IF EXISTS` to a `DROP` statement is a runtime-semantics change: without it, dropping a missing object raises `does not exist` and aborts the migration; with it, the same statement silently no-ops. The choice between "idempotent re-run" and "fail fast on schema drift" belongs to the author, not the linter.
+
+The rule still reports the violation so authors can pick the right form by hand. The `fixable` metadata is removed, the message is unchanged.

--- a/src/rules/require-if-exists.ts
+++ b/src/rules/require-if-exists.ts
@@ -19,7 +19,12 @@ const rule: Rule.RuleModule = {
       category: "Best Practices",
       recommended: false,
     },
-    fixable: "code",
+    // No autofix on purpose. Adding `IF EXISTS` to a `DROP` is a
+    // runtime-semantics change: without it, dropping a missing object
+    // raises an error; with it, the same statement silently no-ops.
+    // The author is the one who decides which behavior is correct for
+    // a given migration (idempotent re-run vs. a guard that fails fast
+    // on schema drift), so the linter only reports — it does not edit.
     schema: [],
     messages: {
       missingIfExists:
@@ -33,17 +38,15 @@ const rule: Rule.RuleModule = {
     }): void => {
       if (node.missing_ok === true) return;
 
-      // Constrain the token search to the visited node's own range.
-      // The previous implementation scanned all file tokens with a
-      // module-scoped cursor, which let the visitor land on a `DROP`
-      // keyword that belonged to an unrelated `ALTER TABLE ... DROP
-      // CONSTRAINT` / `DROP COLUMN` and apply the `IF EXISTS` fix
-      // there. Worse, ESLint's `--fix` loop re-parsed the corrupted
-      // file and inserted a second `IF EXISTS`, producing
-      // `DROP CONSTRAINT IF EXISTS IF EXISTS ...` syntax errors.
-      // postgresql-eslint-parser >= 0.5.2 anchors top-level statement
+      // Constrain the token search to the visited node's own range so
+      // we only report on the `DROP` keyword that opens this statement.
+      // (Earlier `--fix` builds of this rule scanned the whole file and
+      // mis-attributed reports to `ALTER TABLE ... DROP CONSTRAINT` /
+      // `DROP COLUMN`. We keep the bounded scan here for accurate
+      // report locations, even though we no longer autofix.)
+      // postgresql-eslint-parser >= 0.5.3 anchors top-level statement
       // ranges via `stmt_location` / `stmt_len`, so `node.range` is
-      // now reliable.
+      // reliable.
       const range = node.range;
       if (!Array.isArray(range) || range[1] - range[0] <= 0) return;
       const [nodeStart, nodeEnd] = range;
@@ -68,7 +71,6 @@ const rule: Rule.RuleModule = {
       context.report({
         loc: { start: drop.loc.start, end: kind.loc.end },
         messageId: "missingIfExists",
-        fix: (fixer) => fixer.insertTextAfterRange(kind.range, " IF EXISTS"),
       });
     };
     return {

--- a/tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.yaml
+++ b/tests/fixtures/require-if-exists/invalid/drop-after-alter-table-drop-constraint.yaml
@@ -5,13 +5,4 @@ errors:
     column: 1
     endLine: 9
     endColumn: 11
-output: |-
-  -- The bare `DROP TABLE` below must be flagged, but the `DROP CONSTRAINT`
-  -- / `DROP COLUMN` inside the `ALTER TABLE` statements above must be
-  -- left untouched. (Regression: the previous token-cursor scan landed
-  -- the `IF EXISTS` insertion on the first `DROP` keyword in the file,
-  -- i.e. inside the ALTER TABLE, and ESLint's --fix loop ran the rule
-  -- again, producing `DROP CONSTRAINT IF EXISTS IF EXISTS ...`.)
-  ALTER TABLE users DROP CONSTRAINT chk_users_email;
-  ALTER TABLE users DROP COLUMN nickname;
-  DROP TABLE IF EXISTS old_users;
+output: null

--- a/tests/fixtures/require-if-exists/invalid/missing-if-exists.yaml
+++ b/tests/fixtures/require-if-exists/invalid/missing-if-exists.yaml
@@ -23,8 +23,4 @@ errors:
     column: 1
     endLine: 4
     endColumn: 14
-output: |-
-  DROP TABLE IF EXISTS foo;
-  DROP INDEX IF EXISTS idx_foo;
-  DROP FUNCTION IF EXISTS fn();
-  DROP DATABASE IF EXISTS bar;
+output: null


### PR DESCRIPTION
## Summary
- Adding \`IF EXISTS\` to a \`DROP\` statement is a runtime-semantics change: without it, dropping a missing object raises \`does not exist\` and aborts the migration; with it, the same statement silently no-ops.
- The choice between "idempotent re-run" and "fail fast on schema drift" belongs to the author, not the linter — so the \`fix:\` callback and \`fixable\` metadata are dropped.
- The rule still reports the violation so authors can pick the right form by hand.
- Same principle as #220 (\`consistent-create-or-replace\`).

## Test plan
- [x] \`vitest run\` (fixture output fields regenerated to \`output: null\`; error reporting unchanged).
- [x] \`pnpm type:check\` / \`pnpm lint:check\` / \`pnpm format:check\`.