### PR TITLE
fix(prefer-keyword-case): add after-dot guard for trailing dotted field

### DIFF
--- a/.changeset/fix-prefer-keyword-case-field-access.md
+++ b/.changeset/fix-prefer-keyword-case-field-access.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+`postgresql/prefer-keyword-case`: add an after-dot token guard so dotted column references don't have their trailing field uppercased.
+
+Follow-up to the keyword-case identifier-corruption fix. The plugin's `ColumnRef` range-contains check covers most identifier positions, but the parser's `ColumnRef.range` for a dotted expression like `kv.key` / `t.date` only spans the first segment — the second field (`key`, `date`) sits outside any AST-derived identifier range. The rule used to case-fold it, corrupting `kv.key` into `kv.KEY`.
+
+The fix scans tokens in order and exempts every Keyword whose previous non-trivial token is `.` (with the `..` range-operator exception). Same guard already used by `postgresql/plpgsql-keyword-case` for PL/pgSQL bodies.

--- a/src/rules/prefer-keyword-case.ts
+++ b/src/rules/prefer-keyword-case.ts
@@ -271,6 +271,30 @@ const rule: Rule.RuleModule = {
           }
         }
 
+        // Field-access guard: when a Keyword token is the right-hand
+        // side of a dotted reference (`kv.key`, `NEW.role`, `t.date`),
+        // PostgreSQL parses the whole expression as a `ColumnRef` whose
+        // `range` only covers the first dotted segment — the trailing
+        // fields fall outside any AST-derived identifier range. Walk
+        // the tokens in order and flag any Keyword whose previous
+        // non-trivial token is `.` as an identifier.
+        const fieldAccessTokenStarts = new Set<number>();
+        for (let i = 1; i < tokens.length; i++) {
+          const token = tokens[i]!;
+          if (token.type !== "Keyword") continue;
+          const prev = tokens[i - 1]!;
+          if (
+            prev.type === "Punctuator" &&
+            prev.value === "." &&
+            // `..` is not a SQL operator — only single-dot counts.
+            (i < 2 ||
+              tokens[i - 2]!.type !== "Punctuator" ||
+              tokens[i - 2]!.value !== ".")
+          ) {
+            fieldAccessTokenStarts.add(token.range[0]);
+          }
+        }
+
         for (const token of tokens) {
           if (token.type !== "Keyword") continue;
           if (generalIdentifierStarts.has(token.range[0])) continue;
@@ -280,6 +304,7 @@ const rule: Rule.RuleModule = {
             continue;
           }
           if (scopedIdentifierTokenStarts.has(token.range[0])) continue;
+          if (fieldAccessTokenStarts.has(token.range[0])) continue;
 
           let desired: string;
           let messageId: "expectedUpper" | "expectedLower";

--- a/tests/fixtures/prefer-keyword-case/valid/identifier-positions-not-folded.sql
+++ b/tests/fixtures/prefer-keyword-case/valid/identifier-positions-not-folded.sql
@@ -22,3 +22,9 @@ ALTER TABLE bar ADD CONSTRAINT uq_bar_date UNIQUE (date);
 INSERT INTO bar (date, role, value) VALUES ('2025-01-01', 'admin', 'x');
 SELECT date, role, value FROM bar WHERE date > '2024-01-01';
 UPDATE bar SET role = 'y' WHERE date = '2024-01-01';
+
+-- Dotted field access: PostgreSQL's ColumnRef range only covers the
+-- first dotted segment, so the rule's range-contains check doesn't see
+-- the trailing field. The after-dot token guard catches it.
+SELECT kv.key, kv.value FROM jsonb_each('{}') AS kv;
+SELECT t.date, t.role, t.text FROM bar AS t WHERE t.date > '2024-01-01';


### PR DESCRIPTION
## Summary
Follow-up to #224. The plugin's \`ColumnRef\` range-contains check covers most identifier positions, but PostgreSQL's parser gives \`ColumnRef.range\` only the span of the first dotted segment — the second field (\`key\`, \`date\`, \`role\`) sits outside any AST-derived identifier range. The rule used to case-fold it, corrupting \`kv.key\` into \`kv.KEY\` and \`t.date\` into \`t.DATE\`.

The fix walks the file's token stream and exempts every Keyword whose previous non-trivial token is \`.\` (with the \`..\` range-operator exception). Same guard already used by \`plpgsql-keyword-case\` for PL/pgSQL bodies.

## Test plan
- [x] Extended \`identifier-positions-not-folded.sql\` fixture with \`SELECT kv.key, kv.value FROM jsonb_each('{}') AS kv\` and \`SELECT t.date, t.role, t.text FROM bar AS t WHERE t.date > '2024-01-01'\`.
- [x] All 350 plugin tests pass.