### PR TITLE
fix(no-set-search-path): don't flag the search_path pin on function definitions

### DIFF
--- a/.changeset/no-set-search-path-function-scope.md
+++ b/.changeset/no-set-search-path-function-scope.md
@@ -4,4 +4,4 @@
 
 fix(no-set-search-path): do not flag the `search_path` pin on function definitions
 
-A `SET search_path = ...` clause attached to a `CREATE FUNCTION` / `CREATE PROCEDURE` / `ALTER FUNCTION` is the documented mitigation for `search_path` injection and is *required* by `no-security-definer-without-search-path`. Flagging it made the two `recommended` rules mutually unsatisfiable for `SECURITY DEFINER` functions (no value of `search_path`, not even `''`, could satisfy both). The rule now reports only standalone `SET search_path` statements.
+A `SET search_path = ...` clause attached to a `CREATE FUNCTION` / `CREATE PROCEDURE` / `ALTER FUNCTION` is the documented mitigation for `search_path` injection and is _required_ by `no-security-definer-without-search-path`. Flagging it made the two `recommended` rules mutually unsatisfiable for `SECURITY DEFINER` functions (no value of `search_path`, not even `''`, could satisfy both). The rule now reports only standalone `SET search_path` statements.

--- a/.changeset/no-set-search-path-function-scope.md
+++ b/.changeset/no-set-search-path-function-scope.md
@@ -1,0 +1,7 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+fix(no-set-search-path): do not flag the `search_path` pin on function definitions
+
+A `SET search_path = ...` clause attached to a `CREATE FUNCTION` / `CREATE PROCEDURE` / `ALTER FUNCTION` is the documented mitigation for `search_path` injection and is *required* by `no-security-definer-without-search-path`. Flagging it made the two `recommended` rules mutually unsatisfiable for `SECURITY DEFINER` functions (no value of `search_path`, not even `''`, could satisfy both). The rule now reports only standalone `SET search_path` statements.

--- a/src/rules/no-set-search-path.ts
+++ b/src/rules/no-set-search-path.ts
@@ -5,6 +5,11 @@ interface VariableSetStmt {
   name?: string;
 }
 
+interface DefElem {
+  defname?: string;
+  arg?: unknown;
+}
+
 const rule: Rule.RuleModule = {
   meta: {
     type: "suggestion",
@@ -22,9 +27,43 @@ const rule: Rule.RuleModule = {
     },
   },
   create(context) {
+    // A `SET search_path` clause that is part of a function definition
+    // (`CREATE FUNCTION ... SET search_path = ...`, `CREATE PROCEDURE ... SET
+    // search_path = ...`, or `ALTER FUNCTION ... SET search_path = ...`) is NOT
+    // the session-mutating foot-gun this rule targets. It is the documented
+    // mitigation for `search_path` injection and is *required* by the sibling
+    // rule `no-security-definer-without-search-path`. Flagging it makes the two
+    // recommended rules mutually unsatisfiable for `SECURITY DEFINER` functions.
+    //
+    // Such a clause parses as a `VariableSetStmt` nested under a `set` defElem in
+    // the function's `options` (CREATE) or `actions` (ALTER). We record those
+    // nodes up front and skip them, so only standalone `SET search_path`
+    // statements remain reportable. A parent node is always visited before its
+    // children, so the set is recorded before its `VariableSetStmt` is reached.
+    const functionScopedSets = new WeakSet<object>();
+    const collectFunctionSets = (clauses: unknown): void => {
+      if (!Array.isArray(clauses)) return;
+      for (const clause of clauses as DefElem[]) {
+        if (
+          clause?.defname === "set" &&
+          clause.arg !== null &&
+          typeof clause.arg === "object"
+        ) {
+          functionScopedSets.add(clause.arg as object);
+        }
+      }
+    };
+
     return {
+      CreateFunctionStmt(node: { options?: unknown }) {
+        collectFunctionSets(node.options);
+      },
+      AlterFunctionStmt(node: { actions?: unknown }) {
+        collectFunctionSets(node.actions);
+      },
       VariableSetStmt(node: VariableSetStmt) {
         if (node.name !== "search_path") return;
+        if (functionScopedSets.has(node as unknown as object)) return;
         context.report({
           node: node as unknown as Rule.Node,
           messageId: "noSetSearchPath",

--- a/tests/fixtures/no-set-search-path/valid/function-scoped-search-path.sql
+++ b/tests/fixtures/no-set-search-path/valid/function-scoped-search-path.sql
@@ -1,0 +1,27 @@
+-- A `search_path` pin that belongs to a function definition is the documented
+-- mitigation for search_path injection and is required by
+-- `no-security-definer-without-search-path`. It must not be flagged here.
+
+-- Empty search_path with fully-qualified bodies: the strongest hardening.
+CREATE FUNCTION fn() RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$ BEGIN END $$;
+
+-- The non-empty form PostgreSQL's own docs recommend.
+CREATE OR REPLACE FUNCTION fn2() RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$ BEGIN END $$;
+
+-- Procedures share the CreateFunctionStmt node.
+CREATE PROCEDURE pr()
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$ BEGIN END $$;
+
+-- The same pin applied to an existing function.
+ALTER FUNCTION fn() SET search_path = pg_catalog;


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`no-set-search-path` no longer flags a `SET search_path` clause that is part of a function definition (`CREATE FUNCTION` / `CREATE PROCEDURE` / `ALTER FUNCTION`). Only standalone `SET search_path` statements are reported.

## Motivation

`no-set-search-path` and `no-security-definer-without-search-path` — both in `configs.recommended` — give contradictory verdicts on every `SECURITY DEFINER` function:

- `no-security-definer-without-search-path` **requires** a pinned `search_path`.
- `no-set-search-path` **forbids** any `SET search_path`, including that pin, because the function's `SET` clause parses as a `VariableSetStmt` nested under a `set` defElem and the rule only checks `node.name === "search_path"`.

So a `SECURITY DEFINER` function can satisfy one rule or the other, never both. No value of `search_path` works — even `SET search_path = ''` (the strongest hardening, paired with fully-qualified names) is flagged.

The conflict is visible in this repo's own fixtures: `tests/fixtures/no-security-definer-without-search-path/valid/with-set.sql` uses `SET search_path = pg_catalog, pg_temp`, which `no-set-search-path` would flag.

A `SET search_path` that is part of a function definition is the documented mitigation for search_path injection (PostgreSQL docs; Supabase advisor `0011_function_search_path_mutable`), so it should not be reported.

No separate issue was filed: this is a self-contained false-positive fix with a full repro above and a regression test below.

## Changes

- `src/rules/no-set-search-path.ts`: collect the `VariableSetStmt` nodes that are the `arg` of a `set` defElem under `CreateFunctionStmt.options` / `AlterFunctionStmt.actions`, and skip them in the `VariableSetStmt` visitor. Standalone statements are unaffected. The parent node is visited before its children, so the set is recorded before its `VariableSetStmt` is reached — no ancestor/parent lookup needed, matching the existing rule style.
- `tests/fixtures/no-set-search-path/valid/function-scoped-search-path.sql`: new valid fixture covering `SECURITY DEFINER` + `''`, `SECURITY DEFINER` + `pg_catalog, pg_temp`, `CREATE PROCEDURE`, and `ALTER FUNCTION ... SET search_path`.
- Changeset (`patch`).

## Testing

- `pnpm test` — full suite green (351 tests / 90 files).
- The new fixture is load-bearing: reverting the rule change makes `valid/function-scoped-search-path.sql` fail with 4 errors; with the fix it reports 0.
- `tsc --noEmit` clean; `oxlint` clean.

## Breaking changes

None. Strictly narrows false positives; standalone `SET search_path` is still reported. Released as a `patch`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->
