### PR TITLE
build(site): sync site/pnpm-lock.yaml with site/package.json

### DIFF
--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -32,27 +32,27 @@ importers:
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)))
+        version: 3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)))
       '@sveltejs/kit':
-        specifier: ^2.67.0
-        version: 2.70.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3))
+        specifier: ^2.70.2
+        version: 2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3))
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3))
       '@types/node':
-        specifier: ^24.13.2
+        specifier: ^24.13.3
         version: 24.13.3
       svelte:
-        specifier: ^5.56.3
+        specifier: ^5.56.9
         version: 5.56.9
       svelte-check:
-        specifier: ^4.6.0
-        version: 4.7.6(picomatch@4.0.4)(svelte@5.56.9)(typescript@7.0.2)
+        specifier: ^4.7.6
+        version: 4.7.6(picomatch@4.0.5)(svelte@5.56.9)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^8.1.0
+        specifier: ^8.1.5
         version: 8.2.1(@types/node@24.13.3)
 
 packages:
@@ -222,11 +222,6 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/acorn-typescript@1.0.9':
-    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
-    peerDependencies:
-      acorn: ^8.9.0
-
   '@sveltejs/adapter-static@3.0.10':
     resolution: {integrity: sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==}
     peerDependencies:
@@ -252,8 +247,8 @@ packages:
     resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
     engines: {node: '>= 18.0.0'}
 
-  '@sveltejs/vite-plugin-svelte@7.1.2':
-    resolution: {integrity: sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==}
+  '@sveltejs/vite-plugin-svelte@7.3.0':
+    resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
       svelte: ^5.46.4
@@ -545,6 +540,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magic-string@1.2.0:
+    resolution: {integrity: sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -563,10 +561,6 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -840,19 +834,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)))':
     dependencies:
-      acorn: 8.16.0
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)))':
-    dependencies:
-      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3))
-
-  '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3))':
+  '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)))(svelte@5.56.9)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3))
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.16.0)
+      '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -870,10 +860,10 @@ snapshots:
 
   '@sveltejs/load-config@0.2.3': {}
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3))':
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3))':
     dependencies:
       deepmerge: 4.3.1
-      magic-string: 0.30.21
+      magic-string: 1.2.0
       obug: 2.1.1
       svelte: 5.56.9
       vite: 8.2.1(@types/node@24.13.3)
@@ -977,9 +967,9 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   fsevents@2.3.3:
     optional: true
@@ -1049,6 +1039,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.2.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -1058,8 +1052,6 @@ snapshots:
   obug@2.1.1: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -1107,12 +1099,12 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  svelte-check@4.7.6(picomatch@4.0.4)(svelte@5.56.9)(typescript@7.0.2):
+  svelte-check@4.7.6(picomatch@4.0.5)(svelte@5.56.9)(typescript@7.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@sveltejs/load-config': 0.2.3
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.56.9
@@ -1143,8 +1135,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   totalist@3.0.1: {}
 


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`main` は現在 CI が赤です。`site/pnpm-lock.yaml` が `site/package.json` と乖離しており、`Site (build)` ジョブと `Deploy site` ワークフローの `pnpm install --frozen-lockfile` が `ERR_PNPM_OUTDATED_LOCKFILE` で落ちています。lockfile を再生成して緑に戻します。

## Motivation

docs サイトは workspace メンバーではなく sibling install なので、独自の lockfile を持っています。Renovate は #244 で `site/package.json` の devDependencies 6 件（`@sveltejs/kit`, `@sveltejs/vite-plugin-svelte`, `@types/node`, `svelte`, `svelte-check`, `vite`）を bump しましたが、`site/pnpm-lock.yaml` を再生成しませんでした。

その結果、マージ後の `main` で以下が失敗しています:

- CI / Site (build) — [run 32320427435](https://github.com/baseballyama/eslint-plugin-postgresql/actions/runs/32320427435)
- Deploy site — [run 32320390012](https://github.com/baseballyama/eslint-plugin-postgresql/actions/runs/32320390012)

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json
  specifiers in the lockfile don't match specifiers in package.json:
* 6 dependencies are mismatched
```

#258 で追加した drift ガードは PR 時点でこの乖離を検出しますが、既に `main` に入ってしまった乖離そのものは解消していません。この PR がその実体を直します。

## Changes

- `site/pnpm-lock.yaml` を `pnpm install --lockfile-only --ignore-workspace` で再生成。
  - `@sveltejs/vite-plugin-svelte` 7.1.2 → 7.3.0（唯一の実解決バージョン変更）
  - 残り 5 件は specifier のみの更新で、解決先バージョンは既存と同一
  - 付随して `@sveltejs/acorn-typescript` 1.0.9 が落ち、`magic-string@1.2.0` / `picomatch@4.0.5` に集約

公開パッケージ（`eslint-plugin-postgresql`）には一切影響しません。ルール・messageId・configs は変更なしのため changeset は不要です。

## Testing

`site/` で CI と同じ手順を実行し、両方成功することを確認しました。

```bash
cd site
pnpm install --frozen-lockfile --ignore-workspace   # ✅
pnpm build                                          # ✅ built in 5.45s / Wrote site to "build"
```

## Breaking changes

None

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [ ] I have added or updated tests for the change. — N/A: the regression test for
      this class of drift is the `Site (build)` job added in #258; it fails on the
      parent commit and passes here.
- [ ] I have added or updated documentation where user-visible behavior changed. —
      N/A: no user-visible behavior changed.
- [ ] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above. — N/A: not breaking, and the published package is untouched.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR
      represents real work that warrants a maintainer's review, and I am willing to
      defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RSosiWRRabDrtVJs6SMRX
