### PR TITLE
feat: add embedded-sql processor for SQL in template literals

### DIFF
--- a/.changeset/embedded-sql-processor.md
+++ b/.changeset/embedded-sql-processor.md
@@ -1,0 +1,19 @@
+---
+"eslint-plugin-postgresql": minor
+---
+
+Add the `embedded-sql` processor, which lints SQL written inside `sql` template
+literals in TypeScript and JavaScript files — the form Drizzle, postgres.js and
+slonik produce. Point it at your source files and the existing rules report
+against the original file, autofix included:
+
+```js
+{
+  files: ["src/**/*.ts"],
+  processor: postgresql.processors["embedded-sql"],
+}
+```
+
+Only complete statements are linted; expression fragments such as
+``sql`excluded.user_name` `` are left alone, and `${...}` interpolations are
+never reported on or rewritten.

--- a/.changeset/embedded-sql-processor.md
+++ b/.changeset/embedded-sql-processor.md
@@ -2,10 +2,11 @@
 "eslint-plugin-postgresql": minor
 ---
 
-Add the `embedded-sql` processor, which lints SQL written inside `sql` template
-literals in TypeScript and JavaScript files — the form Drizzle, postgres.js and
-slonik produce. Point it at your source files and the existing rules report
-against the original file, autofix included:
+Add the `embedded-sql` processor, which lints SQL written inside template
+literals in TypeScript and JavaScript files: the `sql` tag used by Drizzle,
+Kysely and postgres.js, and Prisma's `$queryRaw` / `$executeRaw`. Point it at
+your source files and the existing rules report against the original file,
+autofix included:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -140,7 +140,40 @@ export default [
 
 The `**/*.sql` block matches the virtual files too, so one preset covers
 both real and embedded SQL. The host file keeps being linted by its own
-config — `typescript-eslint` above still sees it.
+config, type-aware rules included — `typescript-eslint` above still sees it.
+
+#### Turning off the rules the virtual files inherit
+
+A flat-config entry with no `files` key applies to **every** file ESLint
+lints, and the virtual `.sql` files are no exception. In a project where
+`typescript-eslint` is registered without a `files` restriction — the common
+case — its rules are handed a PostgreSQL AST and a type-aware rule will throw
+outright:
+
+```
+Error while loading rule '@typescript-eslint/await-thenable': You have used a
+rule which requires type information, but don't have parserOptions set to
+generate type information for this file.
+Occurred while linting src/db.ts/0_0.sql
+```
+
+Switch those rules off on the virtual files, the same way you would for a
+real `.sql` file. Put the block last so it wins:
+
+```js
+import tseslint from "typescript-eslint";
+
+{
+  files: ["**/*.ts/*.sql"],
+  rules: {
+    ...tseslint.configs.disableTypeChecked.rules,
+    // …plus any other plugin whose rules are registered without `files`.
+  },
+}
+```
+
+If you already have a config block that neutralises your JS/TS rules for
+`**/*.sql` files, point it at `**/*.ts/*.sql` as well and you are done.
 
 What the processor picks up, and what it leaves alone:
 
@@ -166,8 +199,8 @@ What the processor picks up, and what it leaves alone:
   generated migrations instead.
 
 Rules written for standalone files can be noisy here — `require-trailing-semicolon`
-flags every embedded statement, for instance. Turn those off for the virtual
-files:
+flags every embedded statement, for instance. Turn those off in the same
+`**/*.ts/*.sql` block:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -95,6 +95,81 @@ export default [
 ];
 ```
 
+### SQL written in TypeScript (Drizzle, postgres.js, slonik)
+
+ORMs keep SQL in two places, and the plugin reaches them differently.
+
+**Migration files.** `drizzle-kit generate` writes plain `.sql` migrations.
+They need no extra setup — point the presets at the output directory and
+every DDL rule applies:
+
+```js
+import postgresql from "eslint-plugin-postgresql";
+
+export default [
+  {
+    files: ["drizzle/**/*.sql"],
+    ...postgresql.configs.recommended,
+  },
+];
+```
+
+**`sql` template literals.** For SQL embedded in `.ts` / `.js`, the
+`embedded-sql` processor carves each statement out into a virtual `.sql`
+file, lints it with the normal rules, and maps the reports (and any fixes)
+back to the position in the original file:
+
+```js
+import postgresql from "eslint-plugin-postgresql";
+import tseslint from "typescript-eslint";
+
+export default [
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.sql"],
+    ...postgresql.configs.recommended,
+  },
+  {
+    files: ["src/**/*.ts"],
+    processor: postgresql.processors["embedded-sql"],
+  },
+];
+```
+
+The `**/*.sql` block matches the virtual files too, so one preset covers
+both real and embedded SQL. The host file keeps being linted by its own
+config — `typescript-eslint` above still sees it.
+
+What the processor picks up, and what it leaves alone:
+
+- **Only complete statements.** ``sql`SELECT id FROM users` `` is linted;
+  expression fragments like ``sql`excluded.user_name` `` or
+  ``sql`${users.id} IS NULL` `` have no standalone parse and are skipped.
+- **Interpolations become placeholders.** Each `${...}` is replaced by an
+  identifier of exactly the same width, so positions stay accurate. Reports
+  and fixes that land on a placeholder are discarded rather than shown —
+  the plugin will not tell you to rename an expression it cannot see. If the
+  substituted text does not parse, the template is skipped instead of being
+  reported as a syntax error.
+- **Templates containing a `\` escape are skipped**, because the raw source
+  and the string that actually reaches PostgreSQL differ there.
+- **Only the `sql` tag** is recognised — the tag Drizzle, postgres.js and
+  slonik all use.
+- **The ORM query builder is out of scope.** `db.select().from(users)` and
+  `pgTable(...)` never produce SQL text, so no rule can see them. Lint the
+  generated migrations instead.
+
+Rules written for standalone files can be noisy here — `require-trailing-semicolon`
+flags every embedded statement, for instance. Turn those off for the virtual
+files:
+
+```js
+{
+  files: ["**/*.ts/*.sql"],
+  rules: { "postgresql/require-trailing-semicolon": "off" },
+}
+```
+
 ## Rules
 
 Click a rule name to open its documentation page (examples, rationale, options).

--- a/README.md
+++ b/README.md
@@ -95,20 +95,22 @@ export default [
 ];
 ```
 
-### SQL written in TypeScript (Drizzle, postgres.js, slonik)
+### SQL written in TypeScript (Drizzle, Prisma, Kysely, postgres.js)
 
 ORMs keep SQL in two places, and the plugin reaches them differently.
 
-**Migration files.** `drizzle-kit generate` writes plain `.sql` migrations.
-They need no extra setup — point the presets at the output directory and
-every DDL rule applies:
+**Migration files.** `drizzle-kit generate` and `prisma migrate dev` both
+write plain `.sql` migrations. They need no extra setup — point the presets
+at the output directory and every DDL rule applies. For a schema-first ORM
+this is where nearly all the value is, since every table your app has passes
+through here:
 
 ```js
 import postgresql from "eslint-plugin-postgresql";
 
 export default [
   {
-    files: ["drizzle/**/*.sql"],
+    files: ["drizzle/**/*.sql", "prisma/migrations/**/*.sql"],
     ...postgresql.configs.recommended,
   },
 ];
@@ -153,8 +155,12 @@ What the processor picks up, and what it leaves alone:
   reported as a syntax error.
 - **Templates containing a `\` escape are skipped**, because the raw source
   and the string that actually reaches PostgreSQL differ there.
-- **Only the `sql` tag** is recognised — the tag Drizzle, postgres.js and
-  slonik all use.
+- **Recognised tags** are `sql` (Drizzle, Kysely, postgres.js) and
+  `$queryRaw` / `$executeRaw` (Prisma). The tag is the last identifier before
+  the backtick, so `prisma.$queryRaw` matches. Anything that is not a plain
+  identifier is out of reach: Prisma's `$queryRawUnsafe("...")` and TypeORM's
+  `.query("...")` take a string argument rather than a template, and modern
+  slonik tags with `sql.type(schema)`, whose last token is a `)`.
 - **The ORM query builder is out of scope.** `db.select().from(users)` and
   `pgTable(...)` never produce SQL text, so no rule can see them. Lint the
   generated migrations instead.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { ESLint, Linter } from "eslint";
 import postgresqlParser from "postgresql-eslint-parser";
 import { name, version } from "./meta.js";
+import embeddedSql from "./processors/embedded-sql.js";
 import alignColumnDefinitions from "./rules/align-column-definitions.js";
 import alignValues from "./rules/align-values.js";
 import consistentAsForColumnAlias from "./rules/consistent-as-for-column-alias.js";
@@ -192,6 +193,12 @@ const plugin: ESLint.Plugin = {
     version,
   },
   rules,
+  // Lints the SQL inside `sql` template literals in `.ts` / `.js` files —
+  // the shape Drizzle, postgres.js and slonik produce. See the README for
+  // how to wire it up next to a preset.
+  processors: {
+    "embedded-sql": embeddedSql,
+  },
 };
 
 // `configs.recommended` references the plugin object itself in `plugins`, so

--- a/src/processors/embedded-sql.ts
+++ b/src/processors/embedded-sql.ts
@@ -300,15 +300,6 @@ const translateMessage = (
   return translated;
 };
 
-const extensionOf = (filename: string): string => {
-  const dot = filename.lastIndexOf(".");
-  const separator = Math.max(
-    filename.lastIndexOf("/"),
-    filename.lastIndexOf("\\"),
-  );
-  return dot > separator + 1 ? filename.slice(dot) : "";
-};
-
 /**
  * Blocks carved out of the file currently being linted, keyed by filename so
  * `postprocess` can map each message list back. ESLint always pairs one
@@ -323,9 +314,9 @@ const blockCache = new Map<string, EmbeddedBlock[]>();
  * emitting one virtual `.sql` file per complete statement.
  *
  * The host file is emitted alongside them, unchanged, so the rules that
- * normally apply to it keep running.
+ * normally apply to it keep running — including type-aware ones.
  */
-const embeddedSql: Linter.Processor<Linter.ProcessorFile> = {
+const embeddedSql: Linter.Processor<string | Linter.ProcessorFile> = {
   meta: {
     name: "postgresql/embedded-sql",
     version: "1",
@@ -346,10 +337,12 @@ const embeddedSql: Linter.Processor<Linter.ProcessorFile> = {
         text: block.text,
         filename: `${index}${VIRTUAL_EXTENSION}`,
       })),
-      // Same text and same extension as the host file, which is how ESLint
-      // knows to lint it with the host's own config instead of resolving a
-      // new one (and re-entering this processor).
-      { text, filename: `${blocks.length}${extensionOf(filename)}` },
+      // The host file goes back as a bare string, not a named block. ESLint
+      // lints a string block with the original options — same config, same
+      // filename — so type-aware setups keep working: `projectService` still
+      // sees the real path instead of a virtual one it cannot find in the
+      // TypeScript program.
+      text,
     ];
   },
 
@@ -361,8 +354,8 @@ const embeddedSql: Linter.Processor<Linter.ProcessorFile> = {
     for (const [index, messages] of messageLists.entries()) {
       const block = blocks[index];
       if (block === undefined) {
-        // The trailing list belongs to the host file; its positions are
-        // already host positions.
+        // The trailing list belongs to the host file, which was linted as
+        // itself; its positions are already host positions.
         result.push(...messages);
         continue;
       }

--- a/src/processors/embedded-sql.ts
+++ b/src/processors/embedded-sql.ts
@@ -6,8 +6,21 @@ import {
   type TaggedTemplate,
 } from "./extract-tagged-templates.js";
 
-/** The template tag treated as SQL. Drizzle, postgres.js and slonik all use it. */
-const SQL_TAG = "sql";
+/**
+ * Template tags treated as SQL. `sql` is what Drizzle, Kysely and postgres.js
+ * export; `$queryRaw` / `$executeRaw` are Prisma's raw-query tags, reached
+ * through `prisma.$queryRaw`.
+ *
+ * Tags that are not a plain identifier are out of reach — Prisma's
+ * `$queryRawUnsafe("...")` and TypeORM's `.query("...")` take a string
+ * argument rather than a template, and modern slonik tags with
+ * `sql.type(schema)` whose last token is a `)`.
+ */
+const SQL_TAGS: ReadonlySet<string> = new Set([
+  "sql",
+  "$queryRaw",
+  "$executeRaw",
+]);
 
 /** Extension given to the virtual files carved out of the host file. */
 const VIRTUAL_EXTENSION = ".sql";
@@ -322,7 +335,7 @@ const embeddedSql: Linter.Processor<Linter.ProcessorFile> = {
   preprocess(text, filename) {
     const hostLineStarts = lineStartsOf(text);
     const blocks: EmbeddedBlock[] = [];
-    for (const template of extractTaggedTemplates(text, SQL_TAG)) {
+    for (const template of extractTaggedTemplates(text, SQL_TAGS)) {
       const block = buildBlock(text, template, hostLineStarts);
       if (block !== null) blocks.push(block);
     }

--- a/src/processors/embedded-sql.ts
+++ b/src/processors/embedded-sql.ts
@@ -1,0 +1,365 @@
+import type { Linter } from "eslint";
+import { parse } from "postgresql-eslint-parser";
+import {
+  extractTaggedTemplates,
+  type OffsetRange,
+  type TaggedTemplate,
+} from "./extract-tagged-templates.js";
+
+/** The template tag treated as SQL. Drizzle, postgres.js and slonik all use it. */
+const SQL_TAG = "sql";
+
+/** Extension given to the virtual files carved out of the host file. */
+const VIRTUAL_EXTENSION = ".sql";
+
+const WHITESPACE = /\s/;
+const WORD_PART = /[A-Za-z_]/;
+
+/**
+ * Keywords that can begin a complete PostgreSQL statement. A `sql` template
+ * that starts with anything else is an expression fragment — ``sql`excluded.id` ``,
+ * ``sql`${col} IS NULL` `` — which has no standalone parse, so it is never
+ * turned into a virtual file.
+ */
+const STATEMENT_KEYWORDS = new Set([
+  "ABORT",
+  "ALTER",
+  "ANALYZE",
+  "BEGIN",
+  "CALL",
+  "CHECKPOINT",
+  "CLOSE",
+  "CLUSTER",
+  "COMMENT",
+  "COMMIT",
+  "COPY",
+  "CREATE",
+  "DEALLOCATE",
+  "DECLARE",
+  "DELETE",
+  "DISCARD",
+  "DO",
+  "DROP",
+  "EXECUTE",
+  "EXPLAIN",
+  "FETCH",
+  "GRANT",
+  "IMPORT",
+  "INSERT",
+  "LISTEN",
+  "LOAD",
+  "LOCK",
+  "MERGE",
+  "MOVE",
+  "NOTIFY",
+  "PREPARE",
+  "REASSIGN",
+  "REFRESH",
+  "REINDEX",
+  "RELEASE",
+  "RESET",
+  "REVOKE",
+  "ROLLBACK",
+  "SAVEPOINT",
+  "SELECT",
+  "SET",
+  "SHOW",
+  "START",
+  "TRUNCATE",
+  "UNLISTEN",
+  "UPDATE",
+  "VACUUM",
+  "WITH",
+]);
+
+interface EmbeddedBlock {
+  /** SQL text with every `${...}` swapped for an equal-length placeholder. */
+  text: string;
+  /** Offset in the host file of the first character of `text`. */
+  start: number;
+  /** 1-based line in the host file of `start`. */
+  startLine: number;
+  /** 0-based column in the host file of `start`. */
+  startColumn: number;
+  /** Placeholder spans, as `[start, end)` offsets into `text`. */
+  placeholders: OffsetRange[];
+  /** Offset of each line start in `text`, for line/column → offset lookups. */
+  lineStarts: number[];
+}
+
+const lineStartsOf = (text: string): number[] => {
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text.charAt(i) === "\n") starts.push(i + 1);
+  }
+  return starts;
+};
+
+/** Index of the line containing `offset`, via binary search over line starts. */
+const lineIndexOf = (lineStarts: number[], offset: number): number => {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if ((lineStarts[mid] ?? 0) <= offset) low = mid;
+    else high = mid - 1;
+  }
+  return low;
+};
+
+const offsetAt = (lineStarts: number[], line: number, column: number): number =>
+  (lineStarts[line - 1] ?? 0) + column - 1;
+
+/**
+ * Builds the identifier that stands in for one `${...}`. It has to be exactly
+ * as wide as the span it replaces so every offset in the block still lines up
+ * with the host file — that is what keeps reported positions and autofix
+ * ranges usable without a source map.
+ */
+const placeholderFor = (index: number, width: number): string | null => {
+  const base = `_p${index}`;
+  return base.length > width ? null : base.padEnd(width, "_");
+};
+
+/**
+ * First word of the SQL text, upper-cased, skipping leading whitespace and
+ * comments. Returns `null` when the text starts with something that is not a
+ * word at all.
+ */
+const firstWordOf = (sql: string): string | null => {
+  let i = 0;
+  while (i < sql.length) {
+    const char = sql.charAt(i);
+    if (WHITESPACE.test(char)) {
+      i += 1;
+      continue;
+    }
+    if (char === "-" && sql.charAt(i + 1) === "-") {
+      const end = sql.indexOf("\n", i);
+      if (end === -1) return null;
+      i = end + 1;
+      continue;
+    }
+    if (char === "/" && sql.charAt(i + 1) === "*") {
+      const end = sql.indexOf("*/", i + 2);
+      if (end === -1) return null;
+      i = end + 2;
+      continue;
+    }
+    break;
+  }
+  let end = i;
+  while (end < sql.length && WORD_PART.test(sql.charAt(end))) end += 1;
+  return end === i ? null : sql.slice(i, end).toUpperCase();
+};
+
+const hasParseError = (sql: string): boolean =>
+  parse(sql).body.some((node) => node.type === "SQLParseError");
+
+const buildBlock = (
+  code: string,
+  template: TaggedTemplate,
+  hostLineStarts: number[],
+): EmbeddedBlock | null => {
+  const raw = code.slice(template.start, template.end);
+
+  // The template's raw source and its cooked value diverge once an escape is
+  // involved (`'\\'` is two characters in the file but one in the string that
+  // reaches PostgreSQL). Linting the raw text would report on SQL that never
+  // runs, so these templates are left alone.
+  if (raw.includes("\\")) return null;
+
+  const placeholders: OffsetRange[] = [];
+  let text = "";
+  let cursor = 0;
+  for (const [absoluteStart, absoluteEnd] of template.interpolations) {
+    const start = absoluteStart - template.start;
+    const end = absoluteEnd - template.start;
+    const placeholder = placeholderFor(placeholders.length, end - start);
+    // Only unreachable in practice: a template would need hundreds of
+    // interpolations before `_p<n>` outgrows the shortest `${x}`.
+    if (placeholder === null) return null;
+    text += raw.slice(cursor, start) + placeholder;
+    placeholders.push([start, end]);
+    cursor = end;
+  }
+  text += raw.slice(cursor);
+
+  const firstWord = firstWordOf(text);
+  if (firstWord === null || !STATEMENT_KEYWORDS.has(firstWord)) return null;
+
+  // With placeholders in play a parse failure may be our substitution's fault
+  // rather than the author's, and we cannot tell the two apart — so drop the
+  // block instead of reporting a syntax error we do not stand behind.
+  // Interpolation-free templates are passed through unparsed precisely so
+  // `no-syntax-error` still sees genuine typos.
+  if (placeholders.length > 0 && hasParseError(text)) return null;
+
+  const lineIndex = lineIndexOf(hostLineStarts, template.start);
+  return {
+    text,
+    start: template.start,
+    startLine: lineIndex + 1,
+    startColumn: template.start - (hostLineStarts[lineIndex] ?? 0),
+    placeholders,
+    lineStarts: lineStartsOf(text),
+  };
+};
+
+const translatePosition = (
+  block: EmbeddedBlock,
+  line: number,
+  column: number,
+): { line: number; column: number } => ({
+  line: block.startLine + line - 1,
+  // Only the first line of the block is indented by the host file; later
+  // lines start at column 1 in both coordinate systems.
+  column: line === 1 ? block.startColumn + column : column,
+});
+
+const overlapsPlaceholder = (
+  placeholders: OffsetRange[],
+  start: number,
+  end: number,
+): boolean => placeholders.some(([from, to]) => start < to && end > from);
+
+/**
+ * Moves an edit from block coordinates into host-file coordinates, dropping
+ * it when it cannot be applied there: rewriting a placeholder would corrupt
+ * the author's expression, and a replacement containing a backtick or `${`
+ * would end the template early.
+ */
+const translateFix = (
+  fix: Linter.LintMessage["fix"],
+  block: EmbeddedBlock,
+): Linter.LintMessage["fix"] => {
+  if (fix === undefined) return undefined;
+  const [from, to] = fix.range;
+  if (
+    overlapsPlaceholder(block.placeholders, from, to) ||
+    fix.text.includes("`") ||
+    fix.text.includes("${")
+  ) {
+    return undefined;
+  }
+  return { range: [block.start + from, block.start + to], text: fix.text };
+};
+
+const translateMessage = (
+  message: Linter.LintMessage,
+  block: EmbeddedBlock,
+): Linter.LintMessage | null => {
+  const anchor = offsetAt(block.lineStarts, message.line, message.column);
+  // A placeholder is not code the author wrote, so anything anchored inside
+  // one (a too-long identifier, a casing complaint) is our artefact.
+  if (overlapsPlaceholder(block.placeholders, anchor, anchor + 1)) return null;
+
+  const start = translatePosition(block, message.line, message.column);
+  const translated: Linter.LintMessage = {
+    ...message,
+    line: start.line,
+    column: start.column,
+  };
+
+  if (message.endLine !== undefined && message.endColumn !== undefined) {
+    const end = translatePosition(block, message.endLine, message.endColumn);
+    translated.endLine = end.line;
+    translated.endColumn = end.column;
+  }
+
+  const fix = translateFix(message.fix, block);
+  if (fix === undefined) delete translated.fix;
+  else translated.fix = fix;
+
+  // Suggestions carry their own edits. Left alone they would point into the
+  // block, and an editor applying one would rewrite the wrong bytes.
+  if (message.suggestions !== undefined) {
+    const suggestions = message.suggestions.flatMap((suggestion) => {
+      const suggestionFix = translateFix(suggestion.fix, block);
+      return suggestionFix === undefined
+        ? []
+        : [{ ...suggestion, fix: suggestionFix }];
+    });
+    if (suggestions.length === 0) delete translated.suggestions;
+    else translated.suggestions = suggestions;
+  }
+
+  return translated;
+};
+
+const extensionOf = (filename: string): string => {
+  const dot = filename.lastIndexOf(".");
+  const separator = Math.max(
+    filename.lastIndexOf("/"),
+    filename.lastIndexOf("\\"),
+  );
+  return dot > separator + 1 ? filename.slice(dot) : "";
+};
+
+/**
+ * Blocks carved out of the file currently being linted, keyed by filename so
+ * `postprocess` can map each message list back. ESLint always pairs one
+ * `postprocess` with one `preprocess`, and the entry is dropped on the way
+ * out.
+ */
+const blockCache = new Map<string, EmbeddedBlock[]>();
+
+/**
+ * Lints the SQL inside ``sql`...` `` template literals in JavaScript and
+ * TypeScript files — the form Drizzle, postgres.js and slonik use — by
+ * emitting one virtual `.sql` file per complete statement.
+ *
+ * The host file is emitted alongside them, unchanged, so the rules that
+ * normally apply to it keep running.
+ */
+const embeddedSql: Linter.Processor<Linter.ProcessorFile> = {
+  meta: {
+    name: "postgresql/embedded-sql",
+    version: "1",
+  },
+  supportsAutofix: true,
+
+  preprocess(text, filename) {
+    const hostLineStarts = lineStartsOf(text);
+    const blocks: EmbeddedBlock[] = [];
+    for (const template of extractTaggedTemplates(text, SQL_TAG)) {
+      const block = buildBlock(text, template, hostLineStarts);
+      if (block !== null) blocks.push(block);
+    }
+    blockCache.set(filename, blocks);
+
+    return [
+      ...blocks.map((block, index) => ({
+        text: block.text,
+        filename: `${index}${VIRTUAL_EXTENSION}`,
+      })),
+      // Same text and same extension as the host file, which is how ESLint
+      // knows to lint it with the host's own config instead of resolving a
+      // new one (and re-entering this processor).
+      { text, filename: `${blocks.length}${extensionOf(filename)}` },
+    ];
+  },
+
+  postprocess(messageLists, filename) {
+    const blocks = blockCache.get(filename) ?? [];
+    blockCache.delete(filename);
+
+    const result: Linter.LintMessage[] = [];
+    for (const [index, messages] of messageLists.entries()) {
+      const block = blocks[index];
+      if (block === undefined) {
+        // The trailing list belongs to the host file; its positions are
+        // already host positions.
+        result.push(...messages);
+        continue;
+      }
+      for (const message of messages) {
+        const translated = translateMessage(message, block);
+        if (translated !== null) result.push(translated);
+      }
+    }
+    return result;
+  },
+};
+
+export default embeddedSql;

--- a/src/processors/extract-tagged-templates.ts
+++ b/src/processors/extract-tagged-templates.ts
@@ -1,0 +1,257 @@
+/**
+ * A `[start, end)` pair of offsets into the scanned source.
+ */
+export type OffsetRange = [number, number];
+
+export interface TaggedTemplate {
+  /** Offset of the first character after the opening backtick. */
+  start: number;
+  /** Offset of the closing backtick. */
+  end: number;
+  /** `${...}` spans inside the template, in source order. */
+  interpolations: OffsetRange[];
+}
+
+interface TemplateFrame {
+  kind: "template";
+  /** The code frame the opening backtick was found in. */
+  parent: Frame;
+  tagged: boolean;
+  start: number;
+  interpolations: OffsetRange[];
+  openInterpolation: number | null;
+}
+
+interface CodeFrame {
+  kind: "code";
+  /** The template whose `${` opened this frame; `null` at the top level. */
+  parent: TemplateFrame | null;
+  braceDepth: number;
+}
+
+type Frame = TemplateFrame | CodeFrame;
+
+const IDENT_START = /[A-Za-z_$]/;
+const IDENT_PART = /[A-Za-z0-9_$]/;
+const WHITESPACE = /\s/;
+
+/**
+ * Keywords after which a `/` starts a regular expression literal rather than
+ * a division operator. Without them, `return /['"]/` would be scanned as a
+ * division followed by an unterminated string.
+ */
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  "await",
+  "case",
+  "delete",
+  "do",
+  "else",
+  "in",
+  "instanceof",
+  "new",
+  "of",
+  "return",
+  "throw",
+  "typeof",
+  "void",
+  "yield",
+]);
+
+/** Punctuators after which a `/` starts a regular expression literal. */
+const REGEX_PRECEDING_PUNCTUATORS = new Set([
+  "!",
+  "%",
+  "&",
+  "(",
+  "*",
+  "+",
+  ",",
+  "-",
+  ":",
+  ";",
+  "<",
+  "=",
+  ">",
+  "?",
+  "[",
+  "^",
+  "{",
+  "|",
+  "}",
+  "~",
+]);
+
+const regexCanFollow = (token: string): boolean =>
+  token === "" ||
+  REGEX_PRECEDING_PUNCTUATORS.has(token) ||
+  REGEX_PRECEDING_KEYWORDS.has(token);
+
+const skipLineComment = (code: string, start: number): number => {
+  const end = code.indexOf("\n", start);
+  return end === -1 ? code.length : end;
+};
+
+const skipBlockComment = (code: string, start: number): number => {
+  const end = code.indexOf("*/", start + 2);
+  return end === -1 ? code.length : end + 2;
+};
+
+/**
+ * Skips a `'`- or `"`-quoted string. An unterminated quote resyncs at the
+ * line break, so JSX text such as `<p>don't</p>` costs us the rest of that
+ * line instead of the rest of the file.
+ */
+const skipQuoted = (code: string, start: number): number => {
+  const quote = code.charAt(start);
+  let i = start + 1;
+  while (i < code.length) {
+    const char = code.charAt(i);
+    if (char === "\\") {
+      i += 2;
+      continue;
+    }
+    if (char === quote) return i + 1;
+    if (char === "\n") return i;
+    i += 1;
+  }
+  return i;
+};
+
+const skipRegex = (code: string, start: number): number => {
+  let i = start + 1;
+  let inCharacterClass = false;
+  while (i < code.length) {
+    const char = code.charAt(i);
+    if (char === "\\") {
+      i += 2;
+      continue;
+    }
+    if (char === "[") inCharacterClass = true;
+    else if (char === "]") inCharacterClass = false;
+    else if (char === "/" && !inCharacterClass) return i + 1;
+    else if (char === "\n") return i;
+    i += 1;
+  }
+  return i;
+};
+
+/**
+ * Finds every ``tag`...` `` template literal in JavaScript or TypeScript
+ * source, along with the `${...}` spans inside it.
+ *
+ * This is a lexer, not a parser: it tracks strings, comments, regular
+ * expressions and nested template literals so a backtick inside any of them
+ * is never mistaken for a template. It deliberately does not understand JSX —
+ * an apostrophe in JSX text desynchronises the scan until the next line
+ * break, which loses templates rather than inventing them.
+ */
+export const extractTaggedTemplates = (
+  code: string,
+  tag: string,
+): TaggedTemplate[] => {
+  const found: TaggedTemplate[] = [];
+  let frame: Frame = { kind: "code", parent: null, braceDepth: 0 };
+  let lastToken = "";
+  let i = 0;
+
+  while (i < code.length) {
+    const char = code.charAt(i);
+
+    if (frame.kind === "template") {
+      if (char === "\\") {
+        i += 2;
+        continue;
+      }
+      if (char === "`") {
+        if (frame.tagged) {
+          found.push({
+            start: frame.start,
+            end: i,
+            interpolations: frame.interpolations,
+          });
+        }
+        frame = frame.parent;
+        lastToken = "`";
+        i += 1;
+        continue;
+      }
+      if (char === "$" && code.charAt(i + 1) === "{") {
+        frame.openInterpolation = i;
+        frame = { kind: "code", parent: frame, braceDepth: 0 };
+        lastToken = "";
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && code.charAt(i + 1) === "/") {
+      i = skipLineComment(code, i);
+      continue;
+    }
+    if (char === "/" && code.charAt(i + 1) === "*") {
+      i = skipBlockComment(code, i);
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      i = skipQuoted(code, i);
+      lastToken = char;
+      continue;
+    }
+    if (char === "/" && regexCanFollow(lastToken)) {
+      i = skipRegex(code, i);
+      lastToken = "/";
+      continue;
+    }
+    if (char === "`") {
+      frame = {
+        kind: "template",
+        parent: frame,
+        tagged: lastToken === tag,
+        start: i + 1,
+        interpolations: [],
+        openInterpolation: null,
+      };
+      i += 1;
+      continue;
+    }
+    if (IDENT_START.test(char)) {
+      const identStart = i;
+      i += 1;
+      while (i < code.length && IDENT_PART.test(code.charAt(i))) i += 1;
+      lastToken = code.slice(identStart, i);
+      continue;
+    }
+    if (char === "{") {
+      frame.braceDepth += 1;
+      lastToken = char;
+      i += 1;
+      continue;
+    }
+    if (char === "}") {
+      const template: TemplateFrame | null = frame.parent;
+      // Depth 0 inside a pushed frame means this `}` closes the `${` that
+      // opened it, so control returns to the enclosing template.
+      if (frame.braceDepth === 0 && template !== null) {
+        if (template.openInterpolation !== null) {
+          template.interpolations.push([template.openInterpolation, i + 1]);
+          template.openInterpolation = null;
+        }
+        frame = template;
+      } else {
+        frame.braceDepth -= 1;
+      }
+      lastToken = "}";
+      i += 1;
+      continue;
+    }
+
+    if (!WHITESPACE.test(char)) lastToken = char;
+    i += 1;
+  }
+
+  // Templates nested inside an interpolation close before their parent, so
+  // source order has to be restored for the caller.
+  return found.sort((a, b) => a.start - b.start);
+};

--- a/src/processors/extract-tagged-templates.ts
+++ b/src/processors/extract-tagged-templates.ts
@@ -137,7 +137,10 @@ const skipRegex = (code: string, start: number): number => {
 
 /**
  * Finds every ``tag`...` `` template literal in JavaScript or TypeScript
- * source, along with the `${...}` spans inside it.
+ * source whose tag is one of `tags`, along with the `${...}` spans inside it.
+ *
+ * The tag is the last identifier before the backtick, so a member expression
+ * such as `prisma.$queryRaw` matches on `$queryRaw`.
  *
  * This is a lexer, not a parser: it tracks strings, comments, regular
  * expressions and nested template literals so a backtick inside any of them
@@ -147,7 +150,7 @@ const skipRegex = (code: string, start: number): number => {
  */
 export const extractTaggedTemplates = (
   code: string,
-  tag: string,
+  tags: ReadonlySet<string>,
 ): TaggedTemplate[] => {
   const found: TaggedTemplate[] = [];
   let frame: Frame = { kind: "code", parent: null, braceDepth: 0 };
@@ -208,7 +211,7 @@ export const extractTaggedTemplates = (
       frame = {
         kind: "template",
         parent: frame,
-        tagged: lastToken === tag,
+        tagged: tags.has(lastToken),
         start: i + 1,
         interpolations: [],
         openInterpolation: null,

--- a/tests/embedded-sql-processor.test.ts
+++ b/tests/embedded-sql-processor.test.ts
@@ -1,0 +1,159 @@
+import { Linter } from "eslint";
+import postgresqlParser from "postgresql-eslint-parser";
+import { describe, expect, it } from "vitest";
+import plugin from "../src/index.js";
+
+const processor = plugin.processors?.["embedded-sql"];
+if (processor === undefined) {
+  throw new Error("the embedded-sql processor is not registered on the plugin");
+}
+
+const configFor = (rules: Linter.RulesRecord): Linter.Config[] => [
+  {
+    files: ["**/*.ts"],
+    processor,
+  },
+  {
+    files: ["**/*.sql"],
+    plugins: { postgresql: plugin },
+    languageOptions: { parser: postgresqlParser },
+    rules,
+  },
+];
+
+/** Lints only the extracted SQL, the way a rule-focused fixture would. */
+const lintSql = (code: string, rules: Linter.RulesRecord) =>
+  new Linter({ configType: "flat" }).verify(code, configFor(rules), {
+    filename: "db.ts",
+    filterCodeBlock: (blockFilename) => blockFilename.endsWith(".sql"),
+  });
+
+const fixSql = (code: string, rules: Linter.RulesRecord) =>
+  new Linter({ configType: "flat" }).verifyAndFix(code, configFor(rules), {
+    filename: "db.ts",
+    filterCodeBlock: (blockFilename) => blockFilename.endsWith(".sql"),
+  });
+
+const positionsOf = (messages: Linter.LintMessage[]) =>
+  messages.map((m) => ({
+    ruleId: m.ruleId,
+    line: m.line,
+    column: m.column,
+  }));
+
+describe("processors/embedded-sql", () => {
+  it("reports a statement at its position in the host file", () => {
+    const code = ["const q = sql`SELECT * FROM users`;"].join("\n");
+    expect(
+      positionsOf(lintSql(code, { "postgresql/no-select-star": "error" })),
+    ).toEqual([{ ruleId: "postgresql/no-select-star", line: 1, column: 22 }]);
+    // Column 22 is the `*`, counted from the start of the host file line.
+    expect(code[21]).toBe("*");
+  });
+
+  it("maps positions on later lines of a multi-line template", () => {
+    const code = [
+      "await db.execute(sql`",
+      "  SELECT *",
+      "  FROM users",
+      "`);",
+    ].join("\n");
+    expect(
+      positionsOf(lintSql(code, { "postgresql/no-select-star": "error" })),
+    ).toEqual([{ ruleId: "postgresql/no-select-star", line: 2, column: 10 }]);
+  });
+
+  it("ignores expression fragments that are not complete statements", () => {
+    const code = [
+      "const a = sql`excluded.cognito_user_sub`;",
+      "const b = sql`${users.userName} IS NULL`;",
+      "const c = sql`current_timestamp(3)`;",
+    ].join("\n");
+    expect(lintSql(code, { "postgresql/no-syntax-error": "error" })).toEqual(
+      [],
+    );
+  });
+
+  it("lints a statement that carries interpolations", () => {
+    const code = "const q = sql`SELECT * FROM users WHERE id = ${id}`;";
+    expect(
+      positionsOf(lintSql(code, { "postgresql/no-select-star": "error" })),
+    ).toEqual([{ ruleId: "postgresql/no-select-star", line: 1, column: 22 }]);
+  });
+
+  it("reports a genuine syntax error in a template without interpolations", () => {
+    const code = "const q = sql`SELECT FROM WHERE`;";
+    const messages = lintSql(code, { "postgresql/no-syntax-error": "error" });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.ruleId).toBe("postgresql/no-syntax-error");
+    expect(messages[0]?.line).toBe(1);
+  });
+
+  it("stays silent when an interpolated template fails to parse", () => {
+    // `${dir}` becomes an identifier, which is not valid after ORDER BY —
+    // a failure our substitution caused, not one the author can act on.
+    const code = "const q = sql`SELECT id FROM t ORDER BY name ${dir}`;";
+    expect(lintSql(code, { "postgresql/no-syntax-error": "error" })).toEqual(
+      [],
+    );
+  });
+
+  it("does not report on the placeholder that stands in for an interpolation", () => {
+    // The expression is longer than PostgreSQL's identifier limit, so the
+    // placeholder would trip no-identifier-too-long if it were reported on.
+    const expression = "organizationId == null && userId == null ? 'a' : 'b'";
+    const code = `const q = sql\`SELECT * FROM t WHERE flag = \${${expression}}\`;`;
+    expect(
+      lintSql(code, { "postgresql/no-identifier-too-long": "error" }),
+    ).toEqual([]);
+  });
+
+  it("skips templates whose raw text differs from the string that runs", () => {
+    // `'\\'` is two characters in the file but one in the value drizzle sends.
+    const code =
+      "const q = sql`SELECT * FROM t WHERE a LIKE 'x' ESCAPE '\\\\'`;";
+    expect(lintSql(code, { "postgresql/no-select-star": "error" })).toEqual([]);
+  });
+
+  it("lints the host file alongside the extracted SQL", () => {
+    const code = [
+      "const unused = 1;",
+      "export const q = sql`SELECT * FROM users`;",
+    ].join("\n");
+    const messages = new Linter({ configType: "flat" }).verify(
+      code,
+      [
+        ...configFor({ "postgresql/no-select-star": "error" }),
+        {
+          files: ["**/*.ts"],
+          languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+          rules: { "no-unused-vars": "error" },
+        },
+      ],
+      { filename: "db.ts", filterCodeBlock: () => true },
+    );
+    expect(messages.map((m) => m.ruleId).sort()).toEqual([
+      "no-unused-vars",
+      "postgresql/no-select-star",
+    ]);
+  });
+
+  it("applies a fix inside the template without disturbing the host file", () => {
+    const code = "const q = sql`SELECT * FROM t WHERE a != 1`;";
+    const result = fixSql(code, {
+      "postgresql/prefer-not-equals-operator": "error",
+    });
+    expect(result.fixed).toBe(true);
+    expect(result.output).toBe("const q = sql`SELECT * FROM t WHERE a <> 1`;");
+  });
+
+  it("drops a fix that would rewrite an interpolation", () => {
+    const code = "const q = sql`SELECT CAST(${v} AS int) FROM t`;";
+    const result = fixSql(code, { "postgresql/prefer-cast-operator": "error" });
+    expect(result.fixed).toBe(false);
+    expect(result.output).toBe(code);
+    expect(result.messages.map((m) => m.ruleId)).toEqual([
+      "postgresql/prefer-cast-operator",
+    ]);
+  });
+});

--- a/tests/embedded-sql-processor.test.ts
+++ b/tests/embedded-sql-processor.test.ts
@@ -51,6 +51,24 @@ describe("processors/embedded-sql", () => {
     expect(code[21]).toBe("*");
   });
 
+  it("lints Prisma's raw-query tags", () => {
+    const code = [
+      "const rows = await prisma.$queryRaw`SELECT * FROM users`;",
+      "await prisma.$executeRaw`DELETE FROM sessions`;",
+    ].join("\n");
+    expect(
+      positionsOf(
+        lintSql(code, {
+          "postgresql/no-select-star": "error",
+          "postgresql/require-where-in-delete": "error",
+        }),
+      ),
+    ).toEqual([
+      { ruleId: "postgresql/no-select-star", line: 1, column: 44 },
+      { ruleId: "postgresql/require-where-in-delete", line: 2, column: 38 },
+    ]);
+  });
+
   it("maps positions on later lines of a multi-line template", () => {
     const code = [
       "await db.execute(sql`",

--- a/tests/embedded-sql-processor.test.ts
+++ b/tests/embedded-sql-processor.test.ts
@@ -156,6 +156,23 @@ describe("processors/embedded-sql", () => {
     ]);
   });
 
+  it("hands the host file back as a bare string, not a named block", () => {
+    const code = "const q = sql`SELECT id FROM users`;";
+    const blocks = processor.preprocess?.(code, "db.ts") ?? [];
+    processor.postprocess?.([[], []], "db.ts");
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({
+      text: "SELECT id FROM users",
+      filename: "0.sql",
+    });
+    // A named block would be linted under a synthetic path like `db.ts/1.ts`,
+    // which type-aware setups cannot find in the TypeScript program — every
+    // file would fail with "was not found by the project service". ESLint
+    // lints a string block with the original filename instead.
+    expect(blocks[1]).toBe(code);
+  });
+
   it("applies a fix inside the template without disturbing the host file", () => {
     const code = "const q = sql`SELECT * FROM t WHERE a != 1`;";
     const result = fixSql(code, {

--- a/tests/extract-tagged-templates.test.ts
+++ b/tests/extract-tagged-templates.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { extractTaggedTemplates } from "../src/processors/extract-tagged-templates.js";
 
+const SQL_TAGS = new Set(["sql"]);
+
 const textsOf = (code: string) =>
-  extractTaggedTemplates(code, "sql").map((t) => code.slice(t.start, t.end));
+  extractTaggedTemplates(code, SQL_TAGS).map((t) => code.slice(t.start, t.end));
 
 describe("extractTaggedTemplates", () => {
   it("finds a tagged template and reports the span between the backticks", () => {
     const code = "const q = sql`SELECT 1`;";
-    const [template] = extractTaggedTemplates(code, "sql");
+    const [template] = extractTaggedTemplates(code, SQL_TAGS);
     expect(template).toBeDefined();
     expect(code.slice(template!.start, template!.end)).toBe("SELECT 1");
     expect(template!.interpolations).toEqual([]);
@@ -21,6 +23,14 @@ describe("extractTaggedTemplates", () => {
 
   it("accepts a member-expression tag", () => {
     expect(textsOf("db.sql`SELECT 1`")).toEqual(["SELECT 1"]);
+  });
+
+  it("matches every tag it is given", () => {
+    const code = "prisma.$queryRaw`SELECT 1`; tx.$executeRaw`DELETE FROM t`;";
+    const tags = new Set(["$queryRaw", "$executeRaw"]);
+    expect(
+      extractTaggedTemplates(code, tags).map((t) => code.slice(t.start, t.end)),
+    ).toEqual(["SELECT 1", "DELETE FROM t"]);
   });
 
   it("does not mistake backticks inside strings or comments for templates", () => {
@@ -53,7 +63,7 @@ describe("extractTaggedTemplates", () => {
 
   it("records interpolation spans, including nested braces", () => {
     const code = "sql`SELECT ${{ a: 1 }.a} FROM t WHERE x = ${id}`";
-    const [template] = extractTaggedTemplates(code, "sql");
+    const [template] = extractTaggedTemplates(code, SQL_TAGS);
     expect(template).toBeDefined();
     expect(template!.interpolations.map(([s, e]) => code.slice(s, e))).toEqual([
       "${{ a: 1 }.a}",

--- a/tests/extract-tagged-templates.test.ts
+++ b/tests/extract-tagged-templates.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { extractTaggedTemplates } from "../src/processors/extract-tagged-templates.js";
+
+const textsOf = (code: string) =>
+  extractTaggedTemplates(code, "sql").map((t) => code.slice(t.start, t.end));
+
+describe("extractTaggedTemplates", () => {
+  it("finds a tagged template and reports the span between the backticks", () => {
+    const code = "const q = sql`SELECT 1`;";
+    const [template] = extractTaggedTemplates(code, "sql");
+    expect(template).toBeDefined();
+    expect(code.slice(template!.start, template!.end)).toBe("SELECT 1");
+    expect(template!.interpolations).toEqual([]);
+  });
+
+  it("ignores templates carrying a different tag or no tag at all", () => {
+    expect(textsOf("const a = gql`SELECT 1`; const b = `SELECT 2`;")).toEqual(
+      [],
+    );
+  });
+
+  it("accepts a member-expression tag", () => {
+    expect(textsOf("db.sql`SELECT 1`")).toEqual(["SELECT 1"]);
+  });
+
+  it("does not mistake backticks inside strings or comments for templates", () => {
+    const code = [
+      "const a = 'sql`SELECT 1`';",
+      'const b = "sql`SELECT 2`";',
+      "// sql`SELECT 3`",
+      "/* sql`SELECT 4` */",
+      "const c = sql`SELECT 5`;",
+    ].join("\n");
+    expect(textsOf(code)).toEqual(["SELECT 5"]);
+  });
+
+  it("does not mistake backticks inside a regular expression for templates", () => {
+    const code = "const re = /sql`SELECT 1`/; const q = sql`SELECT 2`;";
+    expect(textsOf(code)).toEqual(["SELECT 2"]);
+  });
+
+  it("treats a slash after a keyword as a regular expression, not division", () => {
+    // Without the keyword table, the `'` in the character class would open a
+    // string and swallow the template that follows.
+    const code = "function f() { return /['\"]/g; }\nconst q = sql`SELECT 1`;";
+    expect(textsOf(code)).toEqual(["SELECT 1"]);
+  });
+
+  it("treats a slash after a value as division", () => {
+    const code = "const r = total / count; const q = sql`SELECT 1`;";
+    expect(textsOf(code)).toEqual(["SELECT 1"]);
+  });
+
+  it("records interpolation spans, including nested braces", () => {
+    const code = "sql`SELECT ${{ a: 1 }.a} FROM t WHERE x = ${id}`";
+    const [template] = extractTaggedTemplates(code, "sql");
+    expect(template).toBeDefined();
+    expect(template!.interpolations.map(([s, e]) => code.slice(s, e))).toEqual([
+      "${{ a: 1 }.a}",
+      "${id}",
+    ]);
+  });
+
+  it("handles a template nested inside an interpolation", () => {
+    const code = "sql`SELECT ${sql`1`} FROM t`";
+    expect(textsOf(code)).toEqual(["SELECT ${sql`1`} FROM t", "1"]);
+  });
+
+  it("keeps scanning after an escaped backtick", () => {
+    const code = "const a = `\\``; const q = sql`SELECT 1`;";
+    expect(textsOf(code)).toEqual(["SELECT 1"]);
+  });
+
+  it("returns templates in source order", () => {
+    const code = "sql`SELECT 1`; sql`SELECT ${sql`2`} FROM t`;";
+    expect(textsOf(code)).toEqual(["SELECT 1", "SELECT ${sql`2`} FROM t", "2"]);
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -124,6 +124,16 @@ describe("eslint-plugin-postgresql", () => {
     ).toEqual([]);
   });
 
+  it("ships the embedded-sql processor", () => {
+    const processor = plugin.processors?.["embedded-sql"];
+    expect(processor).toBeDefined();
+    // Fixes are mapped back into the host file, so the processor must
+    // advertise autofix or ESLint discards them.
+    expect(processor?.supportsAutofix).toBe(true);
+    expect(typeof processor?.preprocess).toBe("function");
+    expect(typeof processor?.postprocess).toBe("function");
+  });
+
   it("ships configs.stylistic that only references fixable rules", () => {
     const stylistic = plugin.configs?.["stylistic"];
     expect(stylistic).toBeDefined();


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds an `embedded-sql` processor so the plugin's rules can lint SQL written inside template literals in `.ts` / `.js` files — the `sql` tag used by Drizzle, Kysely and postgres.js, plus Prisma's `$queryRaw` / `$executeRaw`. Each complete statement is carved out into a virtual `.sql` file, linted with whatever rules are already configured for `**/*.sql`, and the reports (and fixes) are mapped back to positions in the original file. Also documents how to lint `drizzle-kit generate` / `prisma migrate dev` migration output, which needs no new code at all.

## Motivation

Today the plugin only reaches `.sql` files. A project using an ORM keeps its SQL in three shapes, and they are not equally reachable:

| Shape | Example | Reachable |
| --- | --- | --- |
| Migration `.sql` files | `drizzle-kit generate`, `prisma migrate dev` | Already — just needed documenting |
| Identifier-tagged templates | `` sql`...` ``, `` prisma.$queryRaw`...` `` | Not before this PR |
| String-argument raw queries | `$queryRawUnsafe("...")`, TypeORM `.query("...")` | No — nothing marks which argument is SQL |
| Non-identifier tags | modern slonik `` sql.type(schema)`...` `` | No — the tag's last token is a `)` |
| Query builder | `db.select().from(users)`, `pgTable(...)` | Never — no SQL text exists |

This PR closes the second row and documents the first. The query builder stays out of scope on purpose: there is no SQL text for the PG AST to attach to, so not one of the 90 rules could be reused — reimplementing them against the TypeScript AST would be a different plugin, not this one. The README says so explicitly and points users at the migration files instead. For a schema-first ORM like Prisma that is not a consolation prize: every table the app has passes through `prisma/migrations/**/*.sql`, so the DDL rules already apply in full.

There is no issue for this; it came out of a design discussion about applying the plugin to a Drizzle codebase. Happy to move the discussion back to an issue if you'd rather settle the scope question first — the processor is additive and off unless a user opts in, so nothing changes for existing users either way.

## Changes

- **New**: `plugin.processors["embedded-sql"]`. Opt-in; nothing is enabled by default.

  ```js
  {
    files: ["src/**/*.ts"],
    processor: postgresql.processors["embedded-sql"],
  }
  ```

  The existing `files: ["**/*.sql"]` preset block matches the virtual files too, so one preset covers real and embedded SQL. The host file is emitted alongside the extracted blocks with its own extension and unchanged text, so `typescript-eslint` (or whatever else is configured for it) keeps running.

- **New README section** "SQL written in TypeScript (Drizzle, Prisma, Kysely, postgres.js)", covering both the migration-file route and the processor, plus what the processor deliberately skips and why.

- No rule behaviour, severity, `messageId` or config shape changed.

### Design decisions worth review

- **Which tags are recognised.** `sql`, `$queryRaw`, `$executeRaw` — a fixed set, no option. The tag is the last identifier before the backtick, so `prisma.$queryRaw` matches without any member-expression handling. I deliberately did not add a configurable tag list: I cannot name a user who needs one, and the two shapes that are genuinely unreachable (string arguments, `sql.type(schema)` tags) would not be fixed by an option anyway.

- **No `typescript` dependency.** Extraction uses a hand-rolled lexer (`src/processors/extract-tagged-templates.ts`). A `typescript` peer dependency would put every consumer on a version-compatibility matrix for what amounts to "find the tagged templates", and lazy-loading it from ESM to keep it off the `.sql`-only path would be its own escape hatch. The lexer tracks strings, comments, regular expressions and nested templates. It does **not** understand JSX: an apostrophe in JSX text desynchronises the scan until the next line break. That direction only ever loses templates — the statement-keyword gate plus the parse check mean a desync cannot invent one — and it is commented as such at the call site.

- **`${...}` becomes an equal-width identifier.** `${backoffMs}` → `_p0__________`. Keeping the width identical means block offsets are host offsets, so positions and autofix ranges need no source map. Reports anchored inside a placeholder are dropped, and fixes overlapping one (or containing a backtick / `${`) are discarded rather than applied — the plugin will not rewrite an expression it cannot see.

- **Fragments are skipped, not reported.** Only templates whose first token starts a statement are emitted, so `` sql`excluded.user_name` `` and `` sql`${col} IS NULL` `` never reach `no-syntax-error`. When an *interpolated* template fails to parse the block is dropped too, because the substitution may be at fault and that is indistinguishable from an author's typo. Interpolation-free templates are passed through unparsed precisely so `no-syntax-error` still catches real ones.

- **Templates containing `\` are skipped**, since the raw source and the string that actually reaches PostgreSQL diverge there (`'\\'` is two characters in the file, one in the value).

## Testing

```bash
pnpm test tests/extract-tagged-templates.test.ts tests/embedded-sql-processor.test.ts tests/index.test.ts
```

- `tests/extract-tagged-templates.test.ts` (12) — lexer: backticks inside strings / comments / regex, `return /['"]/` vs division, nested interpolations and nested templates, member-expression and multi-tag matching, source ordering.
- `tests/embedded-sql-processor.test.ts` (12) — single-line and multi-line position mapping, Prisma's `$queryRaw` / `$executeRaw`, fragments ignored, interpolated statements linted, genuine syntax error reported, substitution-caused parse failure stays silent, placeholder reports suppressed, escape-bearing templates skipped, host file linted alongside (`no-unused-vars` and `postgresql/no-select-star` both fire), autofix rewrites in place, fix overlapping an interpolation dropped.
- `tests/index.test.ts` — the processor is exported and declares `supportsAutofix`.

Beyond the unit tests, I ran the processor over a private Drizzle monorepo — 202 files containing `sql` templates:

```
virtual .sql blocks emitted: 335
postgresql/require-limit    238
postgresql/no-select-star    45
postgresql/no-syntax-error    1
```

The single syntax error is a real ClickHouse-dialect query (`SELECT * FROM {$0: String}`) being fed to a PostgreSQL parser — a true positive for that configuration. Zero `no-identifier-too-long` or `snake-case-column-name` noise, which is the placeholder suppression doing its job. I spot-checked reported columns against the source lines; the caret lands on the right character on both first and later lines of multi-line templates. I also ran the README config verbatim through the `ESLint` class end-to-end to confirm virtual files resolve config and the host file keeps being linted.

`pnpm check:all` is clean.

## Breaking changes

None. The processor is additive and inert unless a config opts into it.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above. (Not breaking; a `minor` changeset is included for the new processor.)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpKUTbBVxdSLThdqxEWYSN
