### PR TITLE
fix: no-cross-join no longer flags CROSS JOIN LATERAL

### DIFF
--- a/.changeset/no-cross-join-lateral.md
+++ b/.changeset/no-cross-join-lateral.md
@@ -1,0 +1,8 @@
+---
+"eslint-plugin-postgresql": patch
+---
+
+`no-cross-join` no longer flags `CROSS JOIN LATERAL`. The right side of a
+LATERAL join is correlated with the row on its left, so it cannot produce the
+unintended cartesian product the rule exists to catch — and there is no
+`ON` clause to write instead. A plain `CROSS JOIN` still reports.

--- a/site/src/lib/data/rules.ts
+++ b/site/src/lib/data/rules.ts
@@ -116,7 +116,7 @@ export const rules: RuleMeta[] = [
     name: "no-cross-join",
     description: "Warn on CROSS JOIN.",
     longDescription:
-      "If the intent really is a cartesian product, write `JOIN ... ON true` so the intent reads back. PostgreSQL rejects `INNER JOIN b` without `ON`/`USING`, so the explicit `CROSS JOIN` is the only form this rule sees in practice.",
+      "If the intent really is a cartesian product, write `JOIN ... ON true` so the intent reads back. PostgreSQL rejects `INNER JOIN b` without `ON`/`USING`, so the explicit `CROSS JOIN` is the only form this rule sees in practice. `CROSS JOIN LATERAL` is exempt: its right side is correlated with the row on its left, so no cartesian product can result.",
     type: "suggestion",
     recommended: "warn",
     fixable: false,
@@ -125,6 +125,7 @@ export const rules: RuleMeta[] = [
     correct: [
       "SELECT * FROM a JOIN b ON a.id = b.id;",
       "SELECT * FROM a JOIN b ON true; -- intentional cartesian",
+      "SELECT a.id, t.tag FROM a CROSS JOIN LATERAL unnest(a.tags) AS t(tag);",
     ],
   },
   {

--- a/src/rules/no-cross-join.ts
+++ b/src/rules/no-cross-join.ts
@@ -1,5 +1,6 @@
 import type { Rule } from "eslint";
 import type { Ast } from "postgresql-eslint-parser";
+import { isRangeFunction, isRangeSubselect } from "../utils/ast.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -19,6 +20,17 @@ const rule: Rule.RuleModule = {
   create(context) {
     return {
       JoinExpr(node: Ast.JoinExpr) {
+        // `CROSS JOIN LATERAL (...)` is the idiomatic way to correlate a
+        // subquery or set-returning function with the row on its left. The
+        // right side references the left, so it cannot produce the unintended
+        // cartesian product this rule exists to catch, and there is no
+        // `ON` clause to write instead.
+        const rarg = node.rarg;
+        const isLateral =
+          (isRangeSubselect(rarg) || isRangeFunction(rarg)) &&
+          rarg.lateral === true;
+        if (isLateral) return;
+
         const isCrossJoin =
           node.jointype === "JOIN_INNER" &&
           !node.quals &&

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -35,6 +35,12 @@ export const isConstraint = (node: unknown): node is Ast.Constraint =>
 export const isSubLink = (node: unknown): node is Ast.SubLink =>
   isObjectWithType(node, "SubLink");
 
+export const isRangeSubselect = (node: unknown): node is Ast.RangeSubselect =>
+  isObjectWithType(node, "RangeSubselect");
+
+export const isRangeFunction = (node: unknown): node is Ast.RangeFunction =>
+  isObjectWithType(node, "RangeFunction");
+
 const isObjectWithType = <T extends string>(
   node: unknown,
   type: T,

--- a/tests/fixtures/no-cross-join/invalid/cross-join-set-returning-functions.sql
+++ b/tests/fixtures/no-cross-join/invalid/cross-join-set-returning-functions.sql
@@ -1,0 +1,3 @@
+SELECT r.id, f.id
+FROM unnest(ARRAY[1, 2]) AS r(id)
+CROSS JOIN unnest(ARRAY[3, 4]) AS f(id);

--- a/tests/fixtures/no-cross-join/invalid/cross-join-set-returning-functions.yaml
+++ b/tests/fixtures/no-cross-join/invalid/cross-join-set-returning-functions.yaml
@@ -1,0 +1,8 @@
+errors:
+  - messageId: noCrossJoin
+    message: Avoid `CROSS JOIN`. Cartesian products are almost always a mistake; use an explicit `JOIN ... ON` with a join condition, or `JOIN ... ON true` if you really do want one.
+    line: 2
+    column: 6
+    endLine: 3
+    endColumn: 29
+output: null

--- a/tests/fixtures/no-cross-join/valid/cross-join-lateral.sql
+++ b/tests/fixtures/no-cross-join/valid/cross-join-lateral.sql
@@ -1,0 +1,13 @@
+-- LATERAL correlates the right side with the current left row, so no
+-- cartesian product is possible and there is no `ON` clause to write.
+SELECT a.id, x.total
+FROM accounts AS a
+CROSS JOIN LATERAL (
+  SELECT sum(amount) AS total
+  FROM payments AS p
+  WHERE p.account_id = a.id
+) AS x;
+
+SELECT a.id, t.tag
+FROM articles AS a
+CROSS JOIN LATERAL unnest(a.tags) AS t(tag);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`no-cross-join` reported `CROSS JOIN LATERAL`. A LATERAL join's right side references the row on its left, so it cannot produce the unintended cartesian product the rule exists to catch. The rule now skips it; a plain `CROSS JOIN` still reports.

## Motivation

No issue for this; it surfaced while running the plugin over a real Drizzle codebase to evaluate a separate feature. **9 of the 10 `no-cross-join` reports were `CROSS JOIN LATERAL`** — the standard per-row subquery / set-returning-function form:

```sql
SELECT a.id, x.total
FROM accounts AS a
CROSS JOIN LATERAL (
  SELECT sum(amount) AS total FROM payments AS p WHERE p.account_id = a.id
) AS x;
```

The rule's advice does not apply here either. There is no join condition to move into an `ON` clause — the correlation lives in the subquery's `WHERE` — and PostgreSQL only offers `CROSS JOIN LATERAL` or `JOIN LATERAL ... ON true`, so "write `JOIN ... ON true` instead" is a pure spelling change with no gain in clarity.

The tenth report was a deliberate `unnest(a) CROSS JOIN unnest(b)` grid. That one is correct, and this PR keeps it reporting.

## Changes

- `no-cross-join` returns early when the join's right side is a `RangeSubselect` or `RangeFunction` with `lateral: true`.
- `utils/ast.ts` gains `isRangeSubselect` / `isRangeFunction` predicates, following the guards already there, so the rule reads `lateral` through a narrowed type instead of a cast.
- Docs catalog gains the carve-out and one more `correct` example.

No `messageId`, severity or config-shape change.

## Testing

```bash
pnpm test tests/no-cross-join.test.ts
```

- `valid/cross-join-lateral.sql` — both LATERAL forms, a correlated subquery and `unnest`. **Fails on the parent commit** (two `noCrossJoin` reports); passes here.
- `invalid/cross-join-set-returning-functions.sql` — `unnest(...) CROSS JOIN unnest(...)`, a genuine cartesian product between two uncorrelated functions, still reports. Without it, a broader "skip anything with a function on the right" fix would pass unnoticed.

`pnpm test:all` is clean.

## Breaking changes

None in the SemVer sense — the rule reports strictly less. Anyone suppressing this exact false positive will find the suppression unused; with `reportUnusedDisableDirectives` on, a now-unused `eslint-disable` for `postgresql/no-cross-join` will be flagged. Worth a release-note line rather than a major bump.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change (including fixtures where applicable).
- [x] I have added or updated documentation (README rule list, rule docs) where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset and flagged it above. (Not breaking; a `patch` changeset is included.)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpKUTbBVxdSLThdqxEWYSN
