### PR TITLE
ci: sync site/pnpm-lock.yaml automatically on Renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,30 +106,63 @@ jobs:
     name: Site (build)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Needed by "Sync lockfile on Renovate PRs" below, which pushes the
+    # regenerated lockfile back to the Renovate branch.
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: site
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # On a pull request this checks out the PR head instead of the merge
+          # commit, so the sync step below has something it can push back to
+          # the branch. Addressed by SHA rather than by branch name so that it
+          # still resolves for a fork PR, whose branch does not exist here.
+          # Empty on push events, where it falls back to the pushed commit.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.19.0"
           cache: "pnpm"
           cache-dependency-path: site/pnpm-lock.yaml
 
+      # Renovate bumps the versions in `site/package.json` but never touches
+      # `site/pnpm-lock.yaml`: it reads the root `pnpm-workspace.yaml`, treats
+      # `site/` as part of that workspace, and only ever runs pnpm at the root.
+      # The `lock-file-maintenance` branch shows this plainly — a run whose only
+      # job is refreshing lockfiles rewrites the root one and leaves the site
+      # one alone. So regenerate it here rather than making the maintainer run
+      # pnpm by hand on every dependency PR. Restricted to Renovate branches:
+      # a human touching `site/package.json` is expected to commit the lockfile
+      # with it, and a fork PR's token cannot push anyway.
+      - name: Sync lockfile on Renovate PRs
+        if: startsWith(github.head_ref, 'renovate/')
+        run: |
+          pnpm install --lockfile-only --ignore-workspace
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "site/pnpm-lock.yaml is already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "build(site): sync site/pnpm-lock.yaml with site/package.json" -- pnpm-lock.yaml
+          git push origin "HEAD:${GITHUB_HEAD_REF}"
+
       # The docs site is a sibling install, not a workspace member, so it has
-      # its own lockfile. Renovate bumps `site/package.json` without
-      # regenerating it, which used to break `Deploy site` only after merge —
-      # this job makes the drift fail on the PR instead.
+      # its own lockfile. `--frozen-lockfile` is the drift guard: on a Renovate
+      # branch the step above has already repaired the lockfile, and anywhere
+      # else drift fails the PR instead of breaking `Deploy site` after merge.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-workspace
 


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`site/pnpm-lock.yaml` は Renovate が依存を bump するたびに `site/package.json` から乖離します。#258 のガードはそれを PR で落としてくれますが、直すのは毎回手作業でした。`Site (build)` ジョブを自己修復化し、Renovate ブランチでは lockfile を再生成して PR ブランチに push するようにします。

## Motivation

Renovate は `site/package.json` のバージョンを bump する一方で `site/pnpm-lock.yaml` を一切触りません。原因は Renovate が root の `pnpm-workspace.yaml` を読み、`site/` をその workspace の一部とみなして root でしか pnpm を実行しないためです。

決定的な証拠が `renovate/lock-file-maintenance` ブランチです。lockfile の再生成だけが仕事のブランチなのに、diff は root の `pnpm-lock.yaml` 1 ファイルのみで `site/pnpm-lock.yaml` は手つかずでした。

```console
$ git diff --stat origin/main...origin/renovate/lock-file-maintenance
 pnpm-lock.yaml | 1279 +++++++++++++++++---------------------------------------
 1 file changed, 382 insertions(+), 897 deletions(-)
```

時期も一致します。pnpm 10 → 11 移行（#210、root `pnpm-workspace.yaml` を pnpm 11 専用の設定構文に書き換え）より前の #199〜#209 では Renovate は `site/pnpm-lock.yaml` を正しく更新していました。#241 以降は #243 / #245 / #247 / #248 / #250 / #251 / #252 と、`site/package.json` だけが変わり lockfile が置き去りにされています。

その結果 #241 由来の乖離が `main` に到達し、`Deploy site` と `CI / Site (build)` が `ERR_PNPM_OUTDATED_LOCKFILE` で落ちました（#260 で解消済み）。#258 のガードは再発時に `main` を守りますが、Renovate は毎週依存を bump するので、このままでは毎回メンテナが手で pnpm を叩くことになります。

Renovate 設定側での対処も検討しましたが、効果を確認できるのが次回 Renovate 実行（週次）で、外した場合は乖離が続きます。CI 側なら今すぐ検証できて確実です。

## Changes

`.github/workflows/ci.yml` の `Site (build)` ジョブのみ変更しています。

- **`Sync lockfile on Renovate PRs` ステップを追加。** `renovate/*` ブランチのときだけ `pnpm install --lockfile-only --ignore-workspace` を実行し、`site/pnpm-lock.yaml` に差分が出たら PR ブランチに push します。差分がなければ何もしません。
  - Renovate ブランチ限定にしたのは、`site/package.json` を手で触る人は lockfile も一緒にコミットするのが筋であり、また fork PR のトークンでは push できないためです。
- **checkout をマージコミットではなく PR head の SHA に変更。** push する対象のコミットが必要なためです。ブランチ名ではなく SHA で指定しているのは、fork PR のブランチはこのリポジトリに存在せず解決できないからです。push events では空になり従来どおりの挙動に戻ります。
- **ジョブに `permissions: contents: write` を付与。** push に必要な最小権限です。
- `Install dependencies` の `--frozen-lockfile` は変更なし。Renovate ブランチでは上のステップが直した後の検証として、それ以外では従来どおりのガードとして機能します。
- 併せてこのジョブの 3 つの action を commit SHA に pin しました。#256 が全ジョブに対して定めた方針ですが、その後に入った #258 でこのジョブだけ未 pin のままでした。

## Testing

ローカルで乖離状態を再現し、ステップの流れをそのまま実行して確認しました。

```bash
# 1. #260 以前の乖離した lockfile に戻す
git checkout 93a3bb8 -- site/pnpm-lock.yaml

# 2. ガードが落ちることを確認
cd site && pnpm install --frozen-lockfile --ignore-workspace
#   ERR_PNPM_OUTDATED_LOCKFILE / 6 dependencies are mismatched

# 3. 追加したステップ本体
pnpm install --lockfile-only --ignore-workspace
git diff --quiet -- pnpm-lock.yaml; echo $?   # → 1 (差分あり = commit へ進む)

# 4. 再生成後にガードとビルドが通ることを確認
pnpm install --frozen-lockfile --ignore-workspace   # ✅
pnpm build                                          # ✅ Wrote site to "build"
```

`prettier --check .github/workflows/ci.yml` も通ります。この PR 自体は `renovate/*` ブランチではないので新ステップはスキップされ、`Site (build)` は従来どおりのガードとして走ります。新ステップが実際に発火する経路は、次の Renovate PR で初めて確認できます。

## Breaking changes

None. 公開パッケージ（ルール、messageId、`configs`）は無変更で、CI のみの変更のため changeset はありません。

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [ ] I have added or updated tests for the change. — N/A: CI 設定の変更で、単体テストの対象がありません。上の手順でステップ本体をローカル実行して確認しています。
- [ ] I have added or updated documentation where user-visible behavior changed. — N/A: ユーザーから見える挙動は変わりません。意図はワークフロー内のコメントに記載しました。
- [ ] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. — N/A: 破壊的変更ではなく、公開パッケージにも影響しません。
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RSosiWRRabDrtVJs6SMRX
